### PR TITLE
fix: cross-platform build issues with pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ cordless = "cordless.cli:main"
 deploy = [
   "boto3>=1.20",
   "botocore[crt]",
+  "uv>=0.11",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cordless"
-version = "1.1.1rc2"
+version = "1.1.2"
 description = "Serverless Discord interactions framework for AWS Lambda"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ pythonpath = ["src"]
 dev = [
     "boto3>=1.20",
     "botocore[crt]",
-    "moto[iam,awslambda,apigatewayv2,events,logs,s3]>=5.0",
+    "moto[iam,awslambda-simple,apigatewayv2,events,logs,s3]>=5.0",
     "pynacl>=1.5",
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cordless"
-version = "1.1.1rc1"
+version = "1.1.1rc2"
 description = "Serverless Discord interactions framework for AWS Lambda"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cordless"
-version = "1.1.0"
+version = "1.1.1rc1"
 description = "Serverless Discord interactions framework for AWS Lambda"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -183,7 +183,8 @@ def _ensure_packages(packages, python_version, architecture="x86_64"):
             capture_output=True,
         )
         if result.returncode != 0:
-            raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)
+            stderr = result.stderr.decode(errors="replace").strip() if result.stderr else ""
+            raise RuntimeError(f"pip install failed for {packages} (exit {result.returncode}): {stderr}")
         try:
             os.rename(staging, cache_dir)
         except OSError:

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -131,7 +131,7 @@ def _packages_cache_dir(packages, python_version, architecture="x86_64"):
 
 
 def _ensure_packages(packages, python_version, architecture="x86_64"):
-    """pip-install Lambda-compatible wheels, cached across deploys.
+    """uv-install Lambda-compatible wheels, cached across deploys.
 
     The cache key is the exact packages list + python version, so unpinned
     specs (e.g. "pillow") stay at whatever version was first installed until
@@ -143,48 +143,35 @@ def _ensure_packages(packages, python_version, architecture="x86_64"):
 
     import shutil
     import subprocess
-    import sys
 
-    abi = "cp" + python_version.replace(".", "")
-    # uv venvs don't ship pip, so search PATH excluding the active venv
-    venv = os.environ.get("VIRTUAL_ENV", "")
-    search_path = os.pathsep.join(
-        d for d in os.environ.get("PATH", "").split(os.pathsep) if not (venv and d.startswith(venv))
-    )
-    python = shutil.which("python3", path=search_path) or shutil.which("python", path=search_path) or sys.executable
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv not found on PATH — install it: https://docs.astral.sh/uv/getting-started/installation/")
 
     os.makedirs(os.path.dirname(cache_dir), exist_ok=True)
     staging = tempfile.mkdtemp(dir=os.path.dirname(cache_dir))
     try:
-        platform = "manylinux2014_aarch64" if architecture == "arm64" else "manylinux2014_x86_64"
+        platform = "aarch64-manylinux2014" if architecture == "arm64" else "x86_64-manylinux2014"
         result = subprocess.run(
             [
-                python,
-                "-m",
+                uv,
                 "pip",
                 "install",
                 "--target",
                 staging,
-                "--platform",
+                "--python-platform",
                 platform,
                 "--python-version",
                 python_version,
-                "--implementation",
-                "cp",
-                "--abi",
-                abi,
-                "--abi",
-                "abi3",  # accept stable-ABI wheels too (pynacl, cryptography, …)
                 "--only-binary",
                 ":all:",
-                "--no-compile",
                 *packages,
             ],
             capture_output=True,
         )
         if result.returncode != 0:
             stderr = result.stderr.decode(errors="replace").strip() if result.stderr else ""
-            raise RuntimeError(f"pip install failed for {packages} (exit {result.returncode}): {stderr}")
+            raise RuntimeError(f"uv pip install failed for {packages} (exit {result.returncode}): {stderr}")
         try:
             os.rename(staging, cache_dir)
         except OSError:

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -143,10 +143,14 @@ def _ensure_packages(packages, python_version, architecture="x86_64"):
 
     import shutil
     import subprocess
+    import sys
 
-    uv = shutil.which("uv")
+    # prefer the uv installed alongside this interpreter (e.g. via cordless[deploy])
+    # before falling back to PATH (e.g. brew, the astral install script)
+    venv_uv = os.path.join(os.path.dirname(sys.executable), "uv")
+    uv = venv_uv if os.path.isfile(venv_uv) else shutil.which("uv")
     if uv is None:
-        raise RuntimeError("uv not found on PATH — install it: https://docs.astral.sh/uv/getting-started/installation/")
+        raise RuntimeError("uv not found — install it: https://docs.astral.sh/uv/getting-started/installation/")
 
     os.makedirs(os.path.dirname(cache_dir), exist_ok=True)
     staging = tempfile.mkdtemp(dir=os.path.dirname(cache_dir))

--- a/src/cordless/upload.py
+++ b/src/cordless/upload.py
@@ -14,14 +14,10 @@ def _cordless_package_dir():
 
 
 def _layer_extras_dir(python_version, architecture="x86_64"):
-    """Fetch pynacl (fast Ed25519 verify) for the layer; None means build without it."""
+    """Fetch pynacl (fast Ed25519 verify) for the layer."""
     from .deploy import _ensure_packages
 
-    try:
-        return _ensure_packages(["pynacl"], python_version, architecture)
-    except Exception as exc:
-        print(f"  (layer extras unavailable, falling back: {exc})")
-        return None
+    return _ensure_packages(["pynacl"], python_version, architecture)
 
 
 def build_layer_zip(python_version=None, architecture="x86_64"):

--- a/uv.lock
+++ b/uv.lock
@@ -266,7 +266,7 @@ wheels = [
 
 [[package]]
 name = "cordless"
-version = "1.1.0"
+version = "1.1.1rc1"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -266,13 +266,14 @@ wheels = [
 
 [[package]]
 name = "cordless"
-version = "1.1.1rc1"
+version = "1.1.1rc2"
 source = { editable = "." }
 
 [package.optional-dependencies]
 deploy = [
     { name = "boto3" },
     { name = "botocore", extra = ["crt"] },
+    { name = "uv" },
 ]
 
 [package.dev-dependencies]
@@ -290,6 +291,7 @@ dev = [
 requires-dist = [
     { name = "boto3", marker = "extra == 'deploy'", specifier = ">=1.20" },
     { name = "botocore", extras = ["crt"], marker = "extra == 'deploy'" },
+    { name = "uv", marker = "extra == 'deploy'", specifier = ">=0.11" },
 ]
 provides-extras = ["deploy"]
 
@@ -1376,6 +1378,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.11.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/a2/bfd6755b40682ef7e775ddb9d52823dea6551352f4244106da4bad37cd3c/uv-0.11.28.tar.gz", hash = "sha256:df86cfd135542a833e9f84708b3b8dbaa987a3b9db85b267062db49ab639d242", size = 5985690, upload-time = "2026-07-07T23:12:47.095Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/5d/507b829e79353fe3dcb2779cde8f64497d9c99f9b08b18b8f55ee3bf1786/uv-0.11.28-py3-none-linux_armv6l.whl", hash = "sha256:ae5bbdb6150adcd625f5fa720b04abf2014247d878d1035f19751bb0e7274543", size = 25893158, upload-time = "2026-07-07T23:11:55.77Z" },
+    { url = "https://files.pythonhosted.org/packages/10/54/50c85a663ce723e061523ab4ac8b01b650077584e80950f9c93fd073979f/uv-0.11.28-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:bb11d94cb848ff58af79e0bb5e4037cd324d27dbe2dabb7746db698b724a9a20", size = 25041511, upload-time = "2026-07-07T23:11:58.885Z" },
+    { url = "https://files.pythonhosted.org/packages/32/e1/49968cab72f16a7d6c45d095d319f9efbe8ce05f3f15c5f7104493694289/uv-0.11.28-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e9eb317b1cdb249887df77ac232d8a9448f26858b2399f9f2949c6a7b9bedf88", size = 23570471, upload-time = "2026-07-07T23:12:01.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4d/c9fe448dcd5cf65a5f054517aa42551b7f0920710a6891d98af321a06b22/uv-0.11.28-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:041e4b80bebc58d7142ac9394370cacd73185fd8d066d6675d14707d83408f6d", size = 25594677, upload-time = "2026-07-07T23:12:04.597Z" },
+    { url = "https://files.pythonhosted.org/packages/07/aa/4c0c71075ba66cc594f856cbd98844058fcb53cb4dd8a6fccda8419562bb/uv-0.11.28-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:185416a5316df8c5442b47178349f1f27fc1034468670ac1fb499eae3b25bd68", size = 25427944, upload-time = "2026-07-07T23:12:07.226Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/77/50fef66f4e26bf771429e1d88f849476d8ed21f0fb0708acaa53dc5772a5/uv-0.11.28-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a4a9fe246cb2882532277f5d5e5bd8a59462981462a2f98426f35ecfca82460e", size = 25448458, upload-time = "2026-07-07T23:12:10.894Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/93/720f45af65ebda460166dc64f3318acd65f7bd3a8e326fbd21810fd920ee/uv-0.11.28-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f7ce6f6015a3e857bc6a663514afa62856b669ee5c1bd120e4c58ac2ef5513d", size = 26917218, upload-time = "2026-07-07T23:12:13.802Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/27/a9b68a15a5fe8db7103bea514c2adb79e9b1114fc8dc96fb39dbd7a5b898/uv-0.11.28-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6b3d0ea11e83b373a2166b82dd0864f5677fbadf98db64541ab2e59c42968905", size = 27771542, upload-time = "2026-07-07T23:12:16.519Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fd/208607a7f5f86188775387fe0839ef97cf8d013e8d0e909140b7fdb7d0d1/uv-0.11.28-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c60294e3be4fa203a04015fc02ac8a31d936e86fde06dcb43c7f8f22661dfff", size = 26972190, upload-time = "2026-07-07T23:12:19.191Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2e/62273ee6c9fbebccd8248c153b44870f81ebf5267c31edf4c095d78537fb/uv-0.11.28-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49fe42df9f42056037473f3876adec1615709b57d3470ed39178ff420f3afb9f", size = 27127688, upload-time = "2026-07-07T23:12:22.43Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8c/b15212904e6f0aa4a3709dc86838c6fa070fe97c7e96b3f10174a26b16e3/uv-0.11.28-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:fab3c31007a611866475824a666f5a721bf0c9335db806355a97fcfba2a6bbb7", size = 25715221, upload-time = "2026-07-07T23:12:25.144Z" },
+    { url = "https://files.pythonhosted.org/packages/64/35/b83b7c599474aaf1277c2224c09679640c2320562155c4b6ece1c6f014c1/uv-0.11.28-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:2e91eb8a0b00d5f4427195fc818bcaa4d8bb4fccb79f4e973e74802419ab06ca", size = 26392793, upload-time = "2026-07-07T23:12:27.848Z" },
+    { url = "https://files.pythonhosted.org/packages/81/49/8093318206dee51b5cfcabbf110892ff63cfd897a5df002e2d8b61350fe6/uv-0.11.28-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:47e3f12fe6f5c80a01639d8df36efde7bdddfc3bbc52250df623547d8d393105", size = 26522809, upload-time = "2026-07-07T23:12:30.757Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c5/b26d82e9297c29c201f61698ee56bba956f94953b23089532d026a97d93f/uv-0.11.28-py3-none-musllinux_1_1_i686.whl", hash = "sha256:d01c7c665511c047f350e587b8b6557c96b61b2eddafbcd8964f0cc2f5b9afbe", size = 26156793, upload-time = "2026-07-07T23:12:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c2/163e89424668d6c01499efbe85a854ad38f07834bde3f2b16df159eab1d5/uv-0.11.28-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:3fcfda468448093f4d5961ca8c068b0aeec2d02f7226d58ee8513321a929fe4f", size = 27327614, upload-time = "2026-07-07T23:12:36.252Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c9/db4cb824777d013272ccfa77db07a4d12bf1584899458c1917a4b5a4069d/uv-0.11.28-py3-none-win32.whl", hash = "sha256:692edef9cf1d2dd69bb9d9fc01f281a82610547900ce227a3cb269cdf988b5ce", size = 24665179, upload-time = "2026-07-07T23:12:38.803Z" },
+    { url = "https://files.pythonhosted.org/packages/40/bc/d67b18cddd54c503c7bad2b189a47fd7a1d07ea10b9212624f892b985498/uv-0.11.28-py3-none-win_amd64.whl", hash = "sha256:f4fcf2c8d9f1444b900e6b8dbbb828825fb76eca01acd18aeaa5c90240408cda", size = 27603677, upload-time = "2026-07-07T23:12:41.985Z" },
+    { url = "https://files.pythonhosted.org/packages/57/94/dc31a771eac989973219c730552dbcf5bf7ea6652dba4ba89b1bbdc75a80/uv-0.11.28-py3-none-win_arm64.whl", hash = "sha256:e94560995737c50525d586da553521fbafe9ef06641e7d885db4b270f53ee84d", size = 25839294, upload-time = "2026-07-07T23:12:44.893Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -280,7 +280,7 @@ deploy = [
 dev = [
     { name = "boto3" },
     { name = "botocore", extra = ["crt"] },
-    { name = "moto", extra = ["apigatewayv2", "awslambda", "events", "s3"] },
+    { name = "moto", extra = ["apigatewayv2", "events", "s3"] },
     { name = "pynacl" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -299,7 +299,7 @@ provides-extras = ["deploy"]
 dev = [
     { name = "boto3", specifier = ">=1.20" },
     { name = "botocore", extras = ["crt"] },
-    { name = "moto", extras = ["iam", "awslambda", "apigatewayv2", "events", "logs", "s3"], specifier = ">=5.0" },
+    { name = "moto", extras = ["iam", "awslambda-simple", "apigatewayv2", "events", "logs", "s3"], specifier = ">=5.0" },
     { name = "pynacl", specifier = ">=1.5" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
@@ -449,20 +449,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
     { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
     { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
-]
-
-[[package]]
-name = "docker"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "requests" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -678,9 +664,6 @@ wheels = [
 apigatewayv2 = [
     { name = "openapi-spec-validator" },
     { name = "pyyaml" },
-]
-awslambda = [
-    { name = "docker" },
 ]
 events = [
     { name = "jsonpath-ng" },
@@ -993,28 +976,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
-name = "pywin32"
-version = "312"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
-    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
-    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
-    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
-    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
-    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -266,7 +266,7 @@ wheels = [
 
 [[package]]
 name = "cordless"
-version = "1.1.1rc2"
+version = "1.1.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Fetching pynacl (and any user-declared `packages`) for the Lambda layer used to silently swallow failures and fall back to a degraded build. On Arch, this hid an error (`No module named pip`) behind a useless message.
- Replaces the pip subprocess (which depended on finding *some* python3 on PATH with a working pip module, fragile across distros) with `uv pip install`, which resolves cross-platform manylinux wheels without needing a system pip at all.
- Any packaging failure (missing uv, failed install) now aborts the deploy with the real error message instead of degrading silently.
- `uv` is added to the `deploy` extra so `pip install cordless[deploy]` / `uv add "cordless[deploy]"` pulls it in automatically, zero extra setup for most users. Lookup prefers the interpreter-local `uv` first, then falls back to PATH (covers brew/curl-script installs too).

## Testing
- [x] Verified `uv pip install --target ... --python-platform x86_64-manylinux2014 --python-version 3.12 --only-binary :all: pynacl` fetches genuine manylinux/glibc wheels from macOS
- [x] Verified `_ensure_packages` raises a clear `RuntimeError` when `uv` is absent from both the interpreter dir and PATH
- [x] Verified a fresh venv with `cordless[deploy]` installed and no system-wide `uv` still deploys successfully (layer + packaging)
- [x] Confirm fix on the reporter's Arch machine
