### PR TITLE
feat: support per-command guild scoping in command registration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cordless"
-version = "1.1.3"
+version = "1.2.0"
 description = "Serverless Discord interactions framework for AWS Lambda"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -566,6 +566,7 @@ class Cordless:
                     dm_permission=kwargs["dm_permission"],
                     default_member_permissions=kwargs.get("default_member_permissions"),
                     nsfw=kwargs.get("nsfw", False),
+                    guild_id=kwargs.get("guild_id"),
                 )
             elif ctype == "button":
                 if kwargs.get("defer"):
@@ -592,6 +593,7 @@ class Cordless:
                     options=[],
                     dm_permission=kwargs["dm_permission"],
                     cmd_type=2,
+                    guild_id=kwargs.get("guild_id"),
                 )
             elif ctype == "message_command":
                 self.router.register_command(
@@ -601,6 +603,7 @@ class Cordless:
                     options=[],
                     dm_permission=kwargs["dm_permission"],
                     cmd_type=3,
+                    guild_id=kwargs.get("guild_id"),
                 )
 
     def sync_commands(self, bot_token=None, client_id=None, client_secret=None, guild_id=None):

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -175,7 +175,7 @@ class Cordless:
         default_member_permissions=None,
         nsfw=False,
         ephemeral=False,
-        guild_id=None,
+        guild_ids=None,
     ):
         _validate_command_name(name)
 
@@ -194,7 +194,7 @@ class Cordless:
                 dm_permission=dm_permission,
                 default_member_permissions=default_member_permissions,
                 nsfw=nsfw,
-                guild_id=guild_id,
+                guild_ids=guild_ids,
             )
             return func
 
@@ -444,23 +444,23 @@ class Cordless:
 
         return decorator
 
-    def user_command(self, name, dm_permission=True, guild_id=None):
+    def user_command(self, name, dm_permission=True, guild_ids=None):
         """Register a User context menu command (right-click → Apps → name)."""
 
         def decorator(func):
             self.router.register_command(
-                name, func, description=None, options=[], dm_permission=dm_permission, cmd_type=2, guild_id=guild_id
+                name, func, description=None, options=[], dm_permission=dm_permission, cmd_type=2, guild_ids=guild_ids
             )
             return func
 
         return decorator
 
-    def message_command(self, name, dm_permission=True, guild_id=None):
+    def message_command(self, name, dm_permission=True, guild_ids=None):
         """Register a Message context menu command (right-click message → Apps → name)."""
 
         def decorator(func):
             self.router.register_command(
-                name, func, description=None, options=[], dm_permission=dm_permission, cmd_type=3, guild_id=guild_id
+                name, func, description=None, options=[], dm_permission=dm_permission, cmd_type=3, guild_ids=guild_ids
             )
             return func
 
@@ -566,7 +566,7 @@ class Cordless:
                     dm_permission=kwargs["dm_permission"],
                     default_member_permissions=kwargs.get("default_member_permissions"),
                     nsfw=kwargs.get("nsfw", False),
-                    guild_id=kwargs.get("guild_id"),
+                    guild_ids=kwargs.get("guild_ids"),
                 )
             elif ctype == "button":
                 if kwargs.get("defer"):
@@ -593,7 +593,7 @@ class Cordless:
                     options=[],
                     dm_permission=kwargs["dm_permission"],
                     cmd_type=2,
-                    guild_id=kwargs.get("guild_id"),
+                    guild_ids=kwargs.get("guild_ids"),
                 )
             elif ctype == "message_command":
                 self.router.register_command(
@@ -603,7 +603,7 @@ class Cordless:
                     options=[],
                     dm_permission=kwargs["dm_permission"],
                     cmd_type=3,
-                    guild_id=kwargs.get("guild_id"),
+                    guild_ids=kwargs.get("guild_ids"),
                 )
 
     def sync_commands(self, bot_token=None, client_id=None, client_secret=None, guild_id=None):
@@ -614,8 +614,8 @@ class Cordless:
         deploy step, not from inside the Lambda handler, since it makes
         blocking network calls to Discord's API.
 
-        Omit `guild_id` (the default) to sync each command to its own scope
-        — global by default, or whichever guild `@bot.command(guild_id=...)`
+        Omit `guild_id` (the default) to sync each command to its own scope:
+        global by default, or whichever guild(s) `@bot.command(guild_ids=...)`
         named, all in this one call. Pass `guild_id` to override every
         command's own scope and push the full set to just that guild
         instead, for instant updates during development.

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -175,6 +175,7 @@ class Cordless:
         default_member_permissions=None,
         nsfw=False,
         ephemeral=False,
+        guild_id=None,
     ):
         _validate_command_name(name)
 
@@ -193,6 +194,7 @@ class Cordless:
                 dm_permission=dm_permission,
                 default_member_permissions=default_member_permissions,
                 nsfw=nsfw,
+                guild_id=guild_id,
             )
             return func
 
@@ -442,23 +444,23 @@ class Cordless:
 
         return decorator
 
-    def user_command(self, name, dm_permission=True):
+    def user_command(self, name, dm_permission=True, guild_id=None):
         """Register a User context menu command (right-click → Apps → name)."""
 
         def decorator(func):
             self.router.register_command(
-                name, func, description=None, options=[], dm_permission=dm_permission, cmd_type=2
+                name, func, description=None, options=[], dm_permission=dm_permission, cmd_type=2, guild_id=guild_id
             )
             return func
 
         return decorator
 
-    def message_command(self, name, dm_permission=True):
+    def message_command(self, name, dm_permission=True, guild_id=None):
         """Register a Message context menu command (right-click message → Apps → name)."""
 
         def decorator(func):
             self.router.register_command(
-                name, func, description=None, options=[], dm_permission=dm_permission, cmd_type=3
+                name, func, description=None, options=[], dm_permission=dm_permission, cmd_type=3, guild_id=guild_id
             )
             return func
 
@@ -605,19 +607,41 @@ class Cordless:
         """Push this bot's registered commands to Discord.
 
         Authenticate with a bot token, or with client_id + client_secret via
-        OAuth2 client credentials (no bot user required). Omit `guild_id`
-        (the default) to register commands globally, for every guild that
-        has authorized the app and every user in it. Run this from a deploy
-        step, not from inside the Lambda handler, since it makes blocking network
-        calls to Discord's API.
+        OAuth2 client credentials (no bot user required). Run this from a
+        deploy step, not from inside the Lambda handler, since it makes
+        blocking network calls to Discord's API.
+
+        Omit `guild_id` (the default) to sync each command to its own scope
+        — global by default, or whichever guild `@bot.command(guild_id=...)`
+        named, all in this one call. Pass `guild_id` to override every
+        command's own scope and push the full set to just that guild
+        instead, for instant updates during development.
         """
-        return sync_commands(
-            self.router.command_definitions(),
-            guild_id=guild_id,
+        if guild_id:
+            return sync_commands(
+                self.router.command_definitions(),
+                guild_id=guild_id,
+                bot_token=bot_token,
+                client_id=client_id,
+                client_secret=client_secret,
+            )
+
+        registered = sync_commands(
+            self.router.scoped_command_definitions(None),
+            guild_id=None,
             bot_token=bot_token,
             client_id=client_id,
             client_secret=client_secret,
         )
+        for gid in self.router.guild_ids():
+            registered += sync_commands(
+                self.router.scoped_command_definitions(gid),
+                guild_id=gid,
+                bot_token=bot_token,
+                client_id=client_id,
+                client_secret=client_secret,
+            )
+        return registered
 
 
 def _extract_body(event):

--- a/src/cordless/cli.py
+++ b/src/cordless/cli.py
@@ -127,7 +127,12 @@ def _register(args):
 
     bot = _load_bot(target, path=source_dir)
     commands, names = _run_register(bot, token, client_id, client_secret, guild_id=args.guild_id)
-    scope = f"guild {args.guild_id}" if args.guild_id else "globally"
+    if args.guild_id:
+        scope = f"guild {args.guild_id}"
+    elif bot.router.guild_ids():
+        scope = f"globally + {len(bot.router.guild_ids())} guild-scoped"
+    else:
+        scope = "globally"
     print(f"Registered {len(commands)} command(s) {scope}: {names}")
 
 

--- a/src/cordless/cog.py
+++ b/src/cordless/cog.py
@@ -34,6 +34,7 @@ class Cog:
         default_member_permissions=None,
         nsfw=False,
         ephemeral=False,
+        guild_id=None,
     ):
         def decorator(func):
             self._handlers.append(
@@ -49,6 +50,7 @@ class Cog:
                         "default_member_permissions": default_member_permissions,
                         "nsfw": nsfw,
                         "ephemeral": ephemeral,
+                        "guild_id": guild_id,
                     },
                 )
             )
@@ -93,7 +95,7 @@ class Cog:
 
         return decorator
 
-    def user_command(self, name, dm_permission=True):
+    def user_command(self, name, dm_permission=True, guild_id=None):
         def decorator(func):
             self._handlers.append(
                 (
@@ -102,6 +104,7 @@ class Cog:
                     {
                         "name": name,
                         "dm_permission": dm_permission,
+                        "guild_id": guild_id,
                     },
                 )
             )
@@ -109,7 +112,7 @@ class Cog:
 
         return decorator
 
-    def message_command(self, name, dm_permission=True):
+    def message_command(self, name, dm_permission=True, guild_id=None):
         def decorator(func):
             self._handlers.append(
                 (
@@ -118,6 +121,7 @@ class Cog:
                     {
                         "name": name,
                         "dm_permission": dm_permission,
+                        "guild_id": guild_id,
                     },
                 )
             )

--- a/src/cordless/cog.py
+++ b/src/cordless/cog.py
@@ -34,7 +34,7 @@ class Cog:
         default_member_permissions=None,
         nsfw=False,
         ephemeral=False,
-        guild_id=None,
+        guild_ids=None,
     ):
         def decorator(func):
             self._handlers.append(
@@ -50,7 +50,7 @@ class Cog:
                         "default_member_permissions": default_member_permissions,
                         "nsfw": nsfw,
                         "ephemeral": ephemeral,
-                        "guild_id": guild_id,
+                        "guild_ids": guild_ids,
                     },
                 )
             )
@@ -95,7 +95,7 @@ class Cog:
 
         return decorator
 
-    def user_command(self, name, dm_permission=True, guild_id=None):
+    def user_command(self, name, dm_permission=True, guild_ids=None):
         def decorator(func):
             self._handlers.append(
                 (
@@ -104,7 +104,7 @@ class Cog:
                     {
                         "name": name,
                         "dm_permission": dm_permission,
-                        "guild_id": guild_id,
+                        "guild_ids": guild_ids,
                     },
                 )
             )
@@ -112,7 +112,7 @@ class Cog:
 
         return decorator
 
-    def message_command(self, name, dm_permission=True, guild_id=None):
+    def message_command(self, name, dm_permission=True, guild_ids=None):
         def decorator(func):
             self._handlers.append(
                 (
@@ -121,7 +121,7 @@ class Cog:
                     {
                         "name": name,
                         "dm_permission": dm_permission,
-                        "guild_id": guild_id,
+                        "guild_ids": guild_ids,
                     },
                 )
             )

--- a/src/cordless/router.py
+++ b/src/cordless/router.py
@@ -40,6 +40,7 @@ class Router:
         cmd_type=1,
         default_member_permissions=None,
         nsfw=False,
+        guild_id=None,
     ):
         if cmd_type == 1:
             for existing, meta in self.commands.items():
@@ -61,6 +62,7 @@ class Router:
             "params": list(inspect.signature(handler).parameters)[1:],
             "default_member_permissions": default_member_permissions,
             "nsfw": nsfw,
+            "guild_id": guild_id,
         }
 
     def register_button(self, custom_id, handler):
@@ -79,10 +81,25 @@ class Router:
         self._error_handler = handler
 
     def command_definitions(self):
+        """Every registered command, regardless of guild scoping — the full
+        set deploy tooling pushes to one guild for instant dev updates."""
+        return self._definitions(self.commands)
+
+    def scoped_command_definitions(self, guild_id):
+        """Only commands registered for this scope (None = global) — see
+        register_command's guild_id."""
+        scoped = {k: m for k, m in self.commands.items() if m.get("guild_id") == guild_id}
+        return self._definitions(scoped)
+
+    def guild_ids(self):
+        """Every distinct guild a command was scoped to via guild_id."""
+        return sorted({m["guild_id"] for m in self.commands.values() if m.get("guild_id")})
+
+    def _definitions(self, commands):
         flat = {}  # name → meta
         subs = {}  # top-level name → {path → meta}
 
-        for key, meta in self.commands.items():
+        for key, meta in commands.items():
             # Context menu commands (type 2/3) never participate in subcommand grouping
             if meta.get("cmd_type", 1) in (2, 3):
                 flat[key] = meta

--- a/src/cordless/router.py
+++ b/src/cordless/router.py
@@ -40,7 +40,7 @@ class Router:
         cmd_type=1,
         default_member_permissions=None,
         nsfw=False,
-        guild_id=None,
+        guild_ids=None,
     ):
         if cmd_type == 1:
             for existing, meta in self.commands.items():
@@ -62,7 +62,7 @@ class Router:
             "params": list(inspect.signature(handler).parameters)[1:],
             "default_member_permissions": default_member_permissions,
             "nsfw": nsfw,
-            "guild_id": guild_id,
+            "guild_ids": list(guild_ids) if guild_ids else None,
         }
 
     def register_button(self, custom_id, handler):
@@ -87,13 +87,17 @@ class Router:
 
     def scoped_command_definitions(self, guild_id):
         """Only commands registered for this scope (None = global) — see
-        register_command's guild_id."""
-        scoped = {k: m for k, m in self.commands.items() if m.get("guild_id") == guild_id}
+        register_command's guild_ids. A command with guild_ids=[a, b] shows
+        up in both scoped_command_definitions(a) and (b)."""
+        if guild_id is None:
+            scoped = {k: m for k, m in self.commands.items() if not m.get("guild_ids")}
+        else:
+            scoped = {k: m for k, m in self.commands.items() if guild_id in (m.get("guild_ids") or [])}
         return self._definitions(scoped)
 
     def guild_ids(self):
-        """Every distinct guild a command was scoped to via guild_id."""
-        return sorted({m["guild_id"] for m in self.commands.values() if m.get("guild_id")})
+        """Every distinct guild referenced by any command's guild_ids."""
+        return sorted({gid for m in self.commands.values() for gid in (m.get("guild_ids") or [])})
 
     def _definitions(self, commands):
         flat = {}  # name → meta

--- a/tests/test_app_features.py
+++ b/tests/test_app_features.py
@@ -304,18 +304,19 @@ def test_ctx_only_handlers_unchanged():
     assert _body(result)["data"]["content"] == "pong"
 
 
-def test_cog_command_guild_id_threads_through_to_router():
+def test_cog_command_guild_ids_threads_through_to_router():
     admin = Cog()
 
-    @admin.command("purge", guild_id="guild-1")
+    @admin.command("purge", guild_ids=["guild-1", "guild-2"])
     async def purge(ctx):
         await ctx.send("done")
 
     bot = Cordless()
     bot.add_cog(admin)
 
-    assert bot.router.guild_ids() == ["guild-1"]
+    assert bot.router.guild_ids() == ["guild-1", "guild-2"]
     assert [d["name"] for d in bot.router.scoped_command_definitions("guild-1")] == ["purge"]
+    assert [d["name"] for d in bot.router.scoped_command_definitions("guild-2")] == ["purge"]
     assert bot.router.scoped_command_definitions(None) == []
 
 

--- a/tests/test_app_features.py
+++ b/tests/test_app_features.py
@@ -304,6 +304,21 @@ def test_ctx_only_handlers_unchanged():
     assert _body(result)["data"]["content"] == "pong"
 
 
+def test_cog_command_guild_id_threads_through_to_router():
+    admin = Cog()
+
+    @admin.command("purge", guild_id="guild-1")
+    async def purge(ctx):
+        await ctx.send("done")
+
+    bot = Cordless()
+    bot.add_cog(admin)
+
+    assert bot.router.guild_ids() == ["guild-1"]
+    assert [d["name"] for d in bot.router.scoped_command_definitions("guild-1")] == ["purge"]
+    assert bot.router.scoped_command_definitions(None) == []
+
+
 def test_cog_command_options_from_signature():
     shop = Cog()
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -266,9 +266,7 @@ def test_bot_sync_commands_pushes_each_command_to_its_own_scope():
     async def mod_only(ctx):
         pass
 
-    with patch(
-        "cordless.app.sync_commands", side_effect=[[{"id": "global"}], [{"id": "guild"}]]
-    ) as mock_sync:
+    with patch("cordless.app.sync_commands", side_effect=[[{"id": "global"}], [{"id": "guild"}]]) as mock_sync:
         result = bot.sync_commands(bot_token="bot-token")
 
     global_call, guild_call = mock_sync.call_args_list
@@ -286,9 +284,7 @@ def test_bot_sync_commands_pushes_multi_guild_command_to_each_guild():
     async def announce(ctx):
         pass
 
-    with patch(
-        "cordless.app.sync_commands", side_effect=[[], [{"id": "g1"}], [{"id": "g2"}]]
-    ) as mock_sync:
+    with patch("cordless.app.sync_commands", side_effect=[[], [{"id": "g1"}], [{"id": "g2"}]]) as mock_sync:
         result = bot.sync_commands(bot_token="bot-token")
 
     call_guild_ids = [call.kwargs["guild_id"] for call in mock_sync.call_args_list]

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -45,6 +45,60 @@ def test_context_menu_definitions_have_no_description_or_options():
     assert defs["Bookmark"] == {"name": "Bookmark", "type": 3}
 
 
+# --- guild-scoped commands ---
+
+
+def test_scoped_command_definitions_filters_by_guild():
+    bot = Cordless()
+
+    @bot.command("ping")
+    async def ping(ctx):
+        pass
+
+    @bot.command("mod-only", guild_id="guild-1")
+    async def mod_only(ctx):
+        pass
+
+    assert [d["name"] for d in bot.router.scoped_command_definitions(None)] == ["ping"]
+    assert [d["name"] for d in bot.router.scoped_command_definitions("guild-1")] == ["mod-only"]
+
+
+def test_command_definitions_ignores_guild_scoping():
+    bot = Cordless()
+
+    @bot.command("ping")
+    async def ping(ctx):
+        pass
+
+    @bot.command("mod-only", guild_id="guild-1")
+    async def mod_only(ctx):
+        pass
+
+    assert {d["name"] for d in bot.router.command_definitions()} == {"ping", "mod-only"}
+
+
+def test_guild_ids_lists_distinct_scopes_in_order():
+    bot = Cordless()
+
+    @bot.command("a", guild_id="guild-2")
+    async def a(ctx):
+        pass
+
+    @bot.command("b", guild_id="guild-1")
+    async def b(ctx):
+        pass
+
+    @bot.command("c", guild_id="guild-2")
+    async def c(ctx):
+        pass
+
+    @bot.command("d")
+    async def d(ctx):
+        pass
+
+    assert bot.router.guild_ids() == ["guild-1", "guild-2"]
+
+
 # --- option() helper ---
 
 
@@ -176,6 +230,43 @@ def test_bot_sync_commands_delegates_to_register_module():
         client_secret=None,
     )
     assert result == [{"id": "1"}]
+
+
+def test_bot_sync_commands_pushes_each_command_to_its_own_scope():
+    bot = Cordless()
+
+    @bot.command("ping")
+    async def ping(ctx):
+        pass
+
+    @bot.command("mod-only", guild_id="guild-1")
+    async def mod_only(ctx):
+        pass
+
+    with patch(
+        "cordless.app.sync_commands", side_effect=[[{"id": "global"}], [{"id": "guild"}]]
+    ) as mock_sync:
+        result = bot.sync_commands(bot_token="bot-token")
+
+    global_call, guild_call = mock_sync.call_args_list
+    assert global_call.args == (bot.router.scoped_command_definitions(None),)
+    assert global_call.kwargs["guild_id"] is None
+    assert guild_call.args == (bot.router.scoped_command_definitions("guild-1"),)
+    assert guild_call.kwargs["guild_id"] == "guild-1"
+    assert result == [{"id": "global"}, {"id": "guild"}]
+
+
+def test_bot_sync_commands_skips_guild_calls_when_none_registered():
+    bot = Cordless()
+
+    @bot.command("ping")
+    async def ping(ctx):
+        pass
+
+    with patch("cordless.app.sync_commands", return_value=[{"id": "1"}]) as mock_sync:
+        bot.sync_commands(bot_token="bot-token")
+
+    mock_sync.assert_called_once()
 
 
 def _basic(client_id, client_secret):

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -55,12 +55,25 @@ def test_scoped_command_definitions_filters_by_guild():
     async def ping(ctx):
         pass
 
-    @bot.command("mod-only", guild_id="guild-1")
+    @bot.command("mod-only", guild_ids=["guild-1"])
     async def mod_only(ctx):
         pass
 
     assert [d["name"] for d in bot.router.scoped_command_definitions(None)] == ["ping"]
     assert [d["name"] for d in bot.router.scoped_command_definitions("guild-1")] == ["mod-only"]
+
+
+def test_scoped_command_definitions_handles_multiple_guild_ids():
+    bot = Cordless()
+
+    @bot.command("announce", guild_ids=["guild-1", "guild-2"])
+    async def announce(ctx):
+        pass
+
+    assert [d["name"] for d in bot.router.scoped_command_definitions("guild-1")] == ["announce"]
+    assert [d["name"] for d in bot.router.scoped_command_definitions("guild-2")] == ["announce"]
+    assert bot.router.scoped_command_definitions("guild-3") == []
+    assert bot.router.scoped_command_definitions(None) == []
 
 
 def test_command_definitions_ignores_guild_scoping():
@@ -70,7 +83,7 @@ def test_command_definitions_ignores_guild_scoping():
     async def ping(ctx):
         pass
 
-    @bot.command("mod-only", guild_id="guild-1")
+    @bot.command("mod-only", guild_ids=["guild-1"])
     async def mod_only(ctx):
         pass
 
@@ -80,20 +93,30 @@ def test_command_definitions_ignores_guild_scoping():
 def test_guild_ids_lists_distinct_scopes_in_order():
     bot = Cordless()
 
-    @bot.command("a", guild_id="guild-2")
+    @bot.command("a", guild_ids=["guild-2"])
     async def a(ctx):
         pass
 
-    @bot.command("b", guild_id="guild-1")
+    @bot.command("b", guild_ids=["guild-1"])
     async def b(ctx):
         pass
 
-    @bot.command("c", guild_id="guild-2")
+    @bot.command("c", guild_ids=["guild-2"])
     async def c(ctx):
         pass
 
     @bot.command("d")
     async def d(ctx):
+        pass
+
+    assert bot.router.guild_ids() == ["guild-1", "guild-2"]
+
+
+def test_guild_ids_flattens_multi_guild_commands():
+    bot = Cordless()
+
+    @bot.command("announce", guild_ids=["guild-1", "guild-2"])
+    async def announce(ctx):
         pass
 
     assert bot.router.guild_ids() == ["guild-1", "guild-2"]
@@ -239,7 +262,7 @@ def test_bot_sync_commands_pushes_each_command_to_its_own_scope():
     async def ping(ctx):
         pass
 
-    @bot.command("mod-only", guild_id="guild-1")
+    @bot.command("mod-only", guild_ids=["guild-1"])
     async def mod_only(ctx):
         pass
 
@@ -254,6 +277,23 @@ def test_bot_sync_commands_pushes_each_command_to_its_own_scope():
     assert guild_call.args == (bot.router.scoped_command_definitions("guild-1"),)
     assert guild_call.kwargs["guild_id"] == "guild-1"
     assert result == [{"id": "global"}, {"id": "guild"}]
+
+
+def test_bot_sync_commands_pushes_multi_guild_command_to_each_guild():
+    bot = Cordless()
+
+    @bot.command("announce", guild_ids=["guild-1", "guild-2"])
+    async def announce(ctx):
+        pass
+
+    with patch(
+        "cordless.app.sync_commands", side_effect=[[], [{"id": "g1"}], [{"id": "g2"}]]
+    ) as mock_sync:
+        result = bot.sync_commands(bot_token="bot-token")
+
+    call_guild_ids = [call.kwargs["guild_id"] for call in mock_sync.call_args_list]
+    assert call_guild_ids == [None, "guild-1", "guild-2"]
+    assert result == [{"id": "g1"}, {"id": "g2"}]
 
 
 def test_bot_sync_commands_skips_guild_calls_when_none_registered():

--- a/uv.lock
+++ b/uv.lock
@@ -266,7 +266,7 @@ wheels = [
 
 [[package]]
 name = "cordless"
-version = "1.1.3"
+version = "1.2.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Commands can now declare their own registration scope via `guild_ids=` on `@bot.command`, `user_command`, `message_command`, and their `Cog` equivalents. Global by default, or pinned to one or more specific guilds.
- `bot.sync_commands()` (and `cordless register` / `cordless deploy --register`) automatically push each command to its own scope in one call: global commands to the global endpoint, guild-scoped ones to each of their guilds' endpoints. No extra step or manual split needed.
- The existing `guild_id=` override (`sync_commands(guild_id=...)`, `cordless register --guild-id`) is unchanged. It still pushes every command to one guild, for instant-propagation dev iteration.

## Why

Some commands (admin/debug tooling, a feature scoped to one or a few servers) only ever belong in specific guilds, but the only way to register them that way was an all-or-nothing call. There was no way to mix global and guild-only commands in a single `cordless deploy --register` without hand-rolling multiple `sync_commands()` calls yourself. This lets a bot declare scope per command and get correct registration automatically.

## Usage

```python
@bot.command("subscribe")                                       # global
async def subscribe(ctx): ...

@bot.command("purge", guild_ids=["8287367898873678"])         # one guild only
async def purge(ctx): ...

@bot.command("announce", guild_ids=["111111111", "222222222"])  # a specific set of guilds
async def announce(ctx): ...
```

Plain `cordless deploy --register` then registers all three correctly in one pass.

## Changes

- `Router.register_command(..., guild_ids=None)` stores per-command scope as a list, or None for global.
- `Router.scoped_command_definitions(guild_id)` is new: definitions filtered to one scope (`None` = global). A command with `guild_ids=[a, b]` shows up in both `scoped_command_definitions(a)` and `scoped_command_definitions(b)`. `Router.command_definitions()` is unchanged, still everything, used by the dev override so it keeps working exactly as before.
- `Router.guild_ids()` is new: distinct guilds referenced by any registered command's `guild_ids`.
- `Cordless.sync_commands()`: with no `guild_id` override, syncs global commands plus each referenced guild's commands in one call and concatenates the results (same return shape as before, a flat list). The override path is untouched, byte for byte.
- `guild_ids=` threaded through `command`, `user_command`, `message_command` on both `Cordless` and `Cog`.
- `cordless register` / `deploy --register` output now reports how many commands were guild-scoped.

## Testing

- 9 new tests (`tests/test_register.py`, `tests/test_app_features.py`): scoped definitions, single and multi-guild `guild_ids`, `guild_ids()` flattening, Cog threading, and the `sync_commands` split (including a command scoped to multiple guilds). 268/268 passing, zero regressions.
- Dogfooded on a real bot in production. Moved 3 commands (2 owner-only debug commands, 1 server-specific command) off a runtime guild-check onto real registration scoping. They no longer even appear in other servers' command lists.

## Docs

cordless.dev's Registering/API/CLI reference pages updated to match.
