### PR TITLE
feat: enhance rate limiting with DynamoDB fallback and retry logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ pythonpath = ["src"]
 dev = [
     "boto3>=1.20",
     "botocore[crt]",
-    "moto[iam,awslambda-simple,apigatewayv2,dynamodb,events,logs,s3]>=5.0",
+    "moto[iam,awslambda-simple,apigatewayv2,events,logs,s3]>=5.0",
     "pynacl>=1.5",
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ pythonpath = ["src"]
 dev = [
     "boto3>=1.20",
     "botocore[crt]",
-    "moto[iam,awslambda-simple,apigatewayv2,events,logs,s3]>=5.0",
+    "moto[iam,awslambda-simple,apigatewayv2,dynamodb,events,logs,s3]>=5.0",
     "pynacl>=1.5",
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -202,9 +202,12 @@ class Cordless:
 
     def _discord_request(self, method, path, payload=None, files=None):
         import json
+        import time
         import urllib.error
         import urllib.request
         from importlib.metadata import version as _ver
+
+        from . import ratelimit
 
         token = os.environ["DISCORD_BOT_TOKEN"]
         if files:
@@ -216,21 +219,32 @@ class Cordless:
             body, content_type = json.dumps(payload).encode(), "application/json"
         else:
             body, content_type = None, None
-        req = urllib.request.Request(
-            f"https://discord.com/api/v10{path}",
-            data=body,
-            headers={
-                "Authorization": f"Bot {token}",
-                "User-Agent": f"DiscordBot (https://cordless.dev, {_ver('cordless')})",
-                **({"Content-Type": content_type} if content_type else {}),
-            },
-            method=method,
-        )
-        try:
-            with urllib.request.urlopen(req) as resp:
-                return resp.read()
-        except urllib.error.HTTPError as exc:
-            raise RuntimeError(f"Discord API error {exc.code}: {exc.read().decode()}") from exc
+        headers = {
+            "Authorization": f"Bot {token}",
+            "User-Agent": f"DiscordBot (https://cordless.dev, {_ver('cordless')})",
+            **({"Content-Type": content_type} if content_type else {}),
+        }
+
+        url = f"https://discord.com/api/v10{path}"
+        ratelimit.wait_if_needed(method, path)
+        for attempt in range(3):
+            req = urllib.request.Request(url, data=body, headers=headers, method=method)
+            try:
+                with urllib.request.urlopen(req) as resp:
+                    data = resp.read()
+                    ratelimit.record_response(method, path, resp.headers)
+                    return data
+            except urllib.error.HTTPError as exc:
+                body_out = exc.read()
+                if exc.code == 429 and attempt < 2:
+                    try:
+                        retry_after = float(json.loads(body_out).get("retry_after", 1))
+                    except (ValueError, AttributeError):
+                        retry_after = 1.0
+                    ratelimit.note_blocked(method, path, retry_after)
+                    time.sleep(min(retry_after, 5))
+                    continue
+                raise RuntimeError(f"Discord API error {exc.code}: {body_out.decode(errors='replace')}") from exc
 
     async def send_message(self, channel_id, content=None, *, embeds=None, components=None, files=None):
         payload = {}

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -226,8 +226,8 @@ class Cordless:
         }
 
         url = f"https://discord.com/api/v10{path}"
-        ratelimit.wait_if_needed(method, path)
         for attempt in range(3):
+            ratelimit.wait_if_needed(method, path)
             req = urllib.request.Request(url, data=body, headers=headers, method=method)
             try:
                 with urllib.request.urlopen(req) as resp:

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -14,6 +14,12 @@ from .verify import verify_signature
 
 PING = 1
 
+# How long _discord_request keeps retrying a 429 before giving up. Matches
+# defer_worker's 30s default timeout - callers doing bursty sends from the
+# main function's default 10s timeout should raise `timeout` in
+# cordless.toml or move the work behind defer_worker.
+_MAX_RETRY_SECONDS = 30.0
+
 _OPTION_TYPES = {
     "string": 3,
     "integer": 4,
@@ -226,7 +232,8 @@ class Cordless:
         }
 
         url = f"https://discord.com/api/v10{path}"
-        for attempt in range(3):
+        deadline = time.monotonic() + _MAX_RETRY_SECONDS
+        while True:
             ratelimit.wait_if_needed(method, path)
             req = urllib.request.Request(url, data=body, headers=headers, method=method)
             try:
@@ -236,7 +243,7 @@ class Cordless:
                     return data
             except urllib.error.HTTPError as exc:
                 body_out = exc.read()
-                if exc.code == 429 and attempt < 2:
+                if exc.code == 429 and time.monotonic() < deadline:
                     try:
                         retry_after = float(json.loads(body_out).get("retry_after", 1))
                     except (ValueError, AttributeError):

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -242,7 +242,7 @@ class Cordless:
                     except (ValueError, AttributeError):
                         retry_after = 1.0
                     ratelimit.note_blocked(method, path, retry_after)
-                    time.sleep(min(retry_after, 5))
+                    time.sleep(ratelimit.jittered_wait(retry_after))
                     continue
                 raise RuntimeError(f"Discord API error {exc.code}: {body_out.decode(errors='replace')}") from exc
 

--- a/src/cordless/cli.py
+++ b/src/cordless/cli.py
@@ -216,6 +216,7 @@ def _deploy(args):
         policies=cfg.get("policies"),
         crons=crons,
         architecture=args.architecture or cfg.get("architecture", "x86_64"),
+        ratelimit=bool(cfg.get("ratelimit", False)),
     )
 
     if args.register:
@@ -271,6 +272,7 @@ def _destroy(args):
         region=region,
         defer_worker=defer_worker,
         layer_name=layer_name,
+        ratelimit=bool(cfg.get("ratelimit", False)),
     )
 
 

--- a/src/cordless/defer.py
+++ b/src/cordless/defer.py
@@ -43,29 +43,33 @@ def invoke_worker(function_name, interaction):
         )
 
 
-def _patch(app_id, token, body, content_type):
-    """PATCH the deferred @original message.
+def _request(method, path, body=None, content_type=None, retry_404=False):
+    """Make a webhooks/{app_id}/{token}/... call.
 
-    Retries on 404 (a warm worker can outrun Discord processing the ACK)
-    and on 429 (honouring retry_after).
+    Retries on 429 (honouring retry_after) always, and on 404 (a warm worker
+    can outrun Discord processing the ACK for @original) when retry_404 is
+    set. Each interaction has its own token, which Discord uses as the
+    bucket's major parameter for these routes, so calls here essentially
+    never share a bucket with another invocation or with send_message's
+    channel buckets - there's nothing for the cross-invocation coordination
+    in ratelimit.py to usefully do here, just a local retry.
     """
+    headers = {"User-Agent": "cordless"}
+    if content_type:
+        headers["Content-Type"] = content_type
+
     status, body_out = 0, b""
     for attempt in range(3):
         conn = HTTPSConnection("discord.com", timeout=_TIMEOUT)
         try:
-            conn.request(
-                "PATCH",
-                f"/api/v10/webhooks/{app_id}/{token}/messages/@original",
-                body,
-                {"Content-Type": content_type, "User-Agent": "cordless"},
-            )
+            conn.request(method, path, body, headers)
             resp = conn.getresponse()
             status = resp.status
             body_out = resp.read()
         finally:
             conn.close()
 
-        if status == 404 and attempt < 2:
+        if status == 404 and retry_404 and attempt < 2:
             time.sleep(0.5)
             continue
         if status == 429 and attempt < 2:
@@ -78,12 +82,18 @@ def _patch(app_id, token, body, content_type):
         break
 
     if status >= 300:
-        print(f"[cordless] followup PATCH {status}: {body_out.decode(errors='replace')}")
+        print(f"[cordless] {method} {path} {status}: {body_out.decode(errors='replace')}")
     return status, body_out
 
 
 def patch_followup(app_id, token, payload):
-    return _patch(app_id, token, json.dumps(payload).encode(), "application/json")
+    return _request(
+        "PATCH",
+        f"/api/v10/webhooks/{app_id}/{token}/messages/@original",
+        json.dumps(payload).encode(),
+        "application/json",
+        retry_404=True,
+    )
 
 
 def patch_followup_with_files(app_id, token, payload, files):
@@ -95,7 +105,9 @@ def patch_followup_with_files(app_id, token, payload, files):
     from ._multipart import build_multipart_body
 
     body, content_type = build_multipart_body(payload, files)
-    return _patch(app_id, token, body, content_type)
+    return _request(
+        "PATCH", f"/api/v10/webhooks/{app_id}/{token}/messages/@original", body, content_type, retry_404=True
+    )
 
 
 def patch_followup_with_file(app_id, token, payload, filename, file_bytes, content_type=None):
@@ -105,37 +117,12 @@ def patch_followup_with_file(app_id, token, payload, filename, file_bytes, conte
 
 def post_followup(app_id, token, payload):
     """POST a new followup message (creates an additional message, does not replace @original)."""
-    conn = HTTPSConnection("discord.com", timeout=_TIMEOUT)
-    try:
-        conn.request(
-            "POST",
-            f"/api/v10/webhooks/{app_id}/{token}",
-            json.dumps(payload).encode(),
-            {"Content-Type": "application/json", "User-Agent": "cordless"},
-        )
-        resp = conn.getresponse()
-        status = resp.status
-        body = resp.read()
-    finally:
-        conn.close()
-    if status >= 300:
-        print(f"[cordless] followup POST {status}: {body.decode(errors='replace')}")
-    return status, body
+    return _request(
+        "POST", f"/api/v10/webhooks/{app_id}/{token}", json.dumps(payload).encode(), "application/json"
+    )
 
 
 def delete_original(app_id, token):
     """DELETE the deferred @original message."""
-    conn = HTTPSConnection("discord.com", timeout=_TIMEOUT)
-    try:
-        conn.request(
-            "DELETE",
-            f"/api/v10/webhooks/{app_id}/{token}/messages/@original",
-            None,
-            {"User-Agent": "cordless"},
-        )
-        resp = conn.getresponse()
-        status = resp.status
-        resp.read()
-    finally:
-        conn.close()
+    status, _ = _request("DELETE", f"/api/v10/webhooks/{app_id}/{token}/messages/@original", retry_404=True)
     return status

--- a/src/cordless/defer.py
+++ b/src/cordless/defer.py
@@ -117,9 +117,7 @@ def patch_followup_with_file(app_id, token, payload, filename, file_bytes, conte
 
 def post_followup(app_id, token, payload):
     """POST a new followup message (creates an additional message, does not replace @original)."""
-    return _request(
-        "POST", f"/api/v10/webhooks/{app_id}/{token}", json.dumps(payload).encode(), "application/json"
-    )
+    return _request("POST", f"/api/v10/webhooks/{app_id}/{token}", json.dumps(payload).encode(), "application/json")
 
 
 def delete_original(app_id, token):

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -68,6 +68,7 @@ _KNOWN_DEPLOY_KEYS = {
     "defer_memory",
     "policies",
     "architecture",
+    "ratelimit",
 }
 
 
@@ -406,6 +407,49 @@ def _allow_worker_invoke(iam, role_name, worker_arn):
     )
 
 
+def ratelimit_table_name(function_name):
+    return f"{function_name}-ratelimit"
+
+
+def ensure_ratelimit_table(dynamodb, table_name):
+    try:
+        dynamodb.describe_table(TableName=table_name)
+        return
+    except dynamodb.exceptions.ResourceNotFoundException:
+        pass
+
+    dynamodb.create_table(
+        TableName=table_name,
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    dynamodb.get_waiter("table_exists").wait(TableName=table_name)
+    dynamodb.update_time_to_live(
+        TableName=table_name,
+        TimeToLiveSpecification={"Enabled": True, "AttributeName": "ttl"},
+    )
+
+
+def _allow_ratelimit_table(iam, role_name, table_arn):
+    iam.put_role_policy(
+        RoleName=role_name,
+        PolicyName="cordless-ratelimit-table",
+        PolicyDocument=json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["dynamodb:GetItem", "dynamodb:PutItem"],
+                        "Resource": table_arn,
+                    }
+                ],
+            }
+        ),
+    )
+
+
 def deploy(
     function_name,
     role_name,
@@ -427,6 +471,7 @@ def deploy(
     policies=None,
     crons=None,
     architecture="x86_64",
+    ratelimit=False,
 ):
     if not function_name:
         raise SystemExit("Function name is required: pass --function or set [deploy] function in cordless.toml")
@@ -445,6 +490,14 @@ def deploy(
 
     with Spinner("IAM role"):
         role_arn = ensure_iam_role(iam, role_name, extra_policies=policies)
+
+    if ratelimit:
+        table_name = ratelimit_table_name(function_name)
+        with Spinner("rate limit table"):
+            ensure_ratelimit_table(session.client("dynamodb"), table_name)
+            table_arn = f"arn:aws:dynamodb:{region}:{account_id}:table/{table_name}"
+            _allow_ratelimit_table(iam, role_name, table_arn)
+        env = {**env, "CORDLESS_RATELIMIT_TABLE": table_name}
 
     if bundle_cordless:
         with Spinner(f"cordless  {_cordless_version()} (local)"):
@@ -606,7 +659,7 @@ def _wire_crons(events, lam, function_name, target_fn, target_arn, crons):
         )
 
 
-def destroy(function_name, role_name, region, defer_worker=None, layer_name=None):
+def destroy(function_name, role_name, region, defer_worker=None, layer_name=None, ratelimit=False):
     if not function_name:
         raise SystemExit("Function name is required: pass --function or set [deploy] function in cordless.toml")
 
@@ -662,5 +715,14 @@ def destroy(function_name, role_name, region, defer_worker=None, layer_name=None
         with Spinner(f"Lambda layer  {layer_name}"):
             for v in _list_all_layer_versions(lam, layer_name):
                 lam.delete_layer_version(LayerName=layer_name, VersionNumber=v["Version"])
+
+    if ratelimit:
+        table_name = ratelimit_table_name(function_name)
+        with Spinner(f"rate limit table  {table_name}"):
+            dynamodb = session.client("dynamodb")
+            try:
+                dynamodb.delete_table(TableName=table_name)
+            except dynamodb.exceptions.ResourceNotFoundException:
+                pass
 
     print(f"  ✓ destroyed {function_name}")

--- a/src/cordless/ratelimit.py
+++ b/src/cordless/ratelimit.py
@@ -1,0 +1,83 @@
+"""Optional cross-invocation coordination for outbound Discord rate limits.
+
+Enabled by setting `ratelimit = true` in [deploy] (cordless.toml), which
+provisions a DynamoDB table and points CORDLESS_RATELIMIT_TABLE at it in the
+deployed function's environment. Header state from Discord's responses is
+cached locally per warm execution environment, which is enough to avoid
+re-requesting a bucket already known to be exhausted. DynamoDB is only
+consulted when that local state is missing (cold start) or already close to
+the limit - not before every request, since most concurrent Lambda
+invocations never touch the same bucket at the same time.
+"""
+
+import os
+import time
+
+_TABLE_ENV_VAR = "CORDLESS_RATELIMIT_TABLE"
+_LOW_REMAINING = 1
+_MAX_WAIT = 5.0
+
+_local = {}
+
+
+def enabled():
+    return bool(os.environ.get(_TABLE_ENV_VAR))
+
+
+def _key(method, path):
+    return f"{method} {path}"
+
+
+def record_response(method, path, headers):
+    """Cache the bucket state Discord returned, for next time this route is called."""
+    if not enabled():
+        return
+    remaining = headers.get("X-RateLimit-Remaining")
+    reset_after = headers.get("X-RateLimit-Reset-After")
+    if remaining is None or reset_after is None:
+        return
+    _local[_key(method, path)] = (int(float(remaining)), time.time() + float(reset_after))
+
+
+def wait_if_needed(method, path):
+    """Block until a bucket is clear, if local or shared state says it isn't."""
+    if not enabled():
+        return
+    key = _key(method, path)
+    cached = _local.get(key)
+    if cached and cached[0] > _LOW_REMAINING and cached[1] > time.time():
+        return
+    blocked_until = _shared_block(key)
+    if blocked_until and blocked_until > time.time():
+        time.sleep(min(blocked_until - time.time(), _MAX_WAIT))
+
+
+def note_blocked(method, path, retry_after):
+    """Record a 429 so other concurrent invocations see the same bucket is blocked."""
+    if not enabled():
+        return
+    key = _key(method, path)
+    blocked_until = time.time() + retry_after
+    _local[key] = (0, blocked_until)
+    _put_shared(key, blocked_until)
+
+
+def _table():
+    import boto3
+
+    return boto3.resource("dynamodb").Table(os.environ[_TABLE_ENV_VAR])
+
+
+def _shared_block(key):
+    try:
+        item = _table().get_item(Key={"pk": key}).get("Item")
+    except Exception:
+        return None  # fail-open: a DynamoDB hiccup should never block sending
+    return item["blocked_until"] if item else None
+
+
+def _put_shared(key, blocked_until):
+    try:
+        _table().put_item(Item={"pk": key, "blocked_until": int(blocked_until) + 1, "ttl": int(blocked_until) + 60})
+    except Exception:
+        pass  # fail-open, same as above

--- a/src/cordless/ratelimit.py
+++ b/src/cordless/ratelimit.py
@@ -46,8 +46,11 @@ def wait_if_needed(method, path):
     key = _key(method, path)
     cached = _local.get(key)
     if cached and cached[0] > _LOW_REMAINING and cached[1] > time.time():
-        return
-    blocked_until = _shared_block(key)
+        return  # comfortably clear locally, no need to ask anyone
+    # not clear (or unknown) locally - local state is still a valid wait source on
+    # its own, since DynamoDB can be unreachable/unconfigured and fails open to None
+    candidates = [t for t in (cached[1] if cached else None, _shared_block(key)) if t]
+    blocked_until = max(candidates, default=None)
     if blocked_until and blocked_until > time.time():
         time.sleep(min(blocked_until - time.time(), _MAX_WAIT))
 

--- a/src/cordless/ratelimit.py
+++ b/src/cordless/ratelimit.py
@@ -89,7 +89,9 @@ def _shared_block(key):
         item = _table().get_item(Key={"pk": key}).get("Item")
     except Exception:
         return None  # fail-open: a DynamoDB hiccup should never block sending
-    return item["blocked_until"] if item else None
+    # boto3's resource API deserializes DynamoDB's Number type as decimal.Decimal,
+    # not float - cast here so callers can freely mix it with time.time() etc.
+    return float(item["blocked_until"]) if item else None
 
 
 def _put_shared(key, blocked_until):

--- a/src/cordless/ratelimit.py
+++ b/src/cordless/ratelimit.py
@@ -49,7 +49,14 @@ def record_response(method, path, headers):
     reset_after = headers.get("X-RateLimit-Reset-After")
     if remaining is None or reset_after is None:
         return
-    _local[_key(method, path)] = (int(float(remaining)), time.time() + float(reset_after))
+    remaining = int(float(remaining))
+    reset_at = time.time() + float(reset_after)
+    key = _key(method, path)
+    _local[key] = (remaining, reset_at)
+    if remaining <= _LOW_REMAINING:
+        # publish proactively, so a concurrent invocation can back off before
+        # it ever gets a 429 itself, not just after someone else already has
+        _put_shared(key, reset_at)
 
 
 def wait_if_needed(method, path):

--- a/src/cordless/ratelimit.py
+++ b/src/cordless/ratelimit.py
@@ -11,6 +11,7 @@ invocations never touch the same bucket at the same time.
 """
 
 import os
+import random
 import time
 
 _TABLE_ENV_VAR = "CORDLESS_RATELIMIT_TABLE"
@@ -22,6 +23,18 @@ _local = {}
 
 def enabled():
     return bool(os.environ.get(_TABLE_ENV_VAR))
+
+
+def jittered_wait(seconds):
+    """Equal jitter: wait at least half the requested time, capped at _MAX_WAIT.
+
+    Concurrent callers given the same `seconds` (e.g. several requests that
+    all just got the same Discord retry_after) spread out across the second
+    half of the window instead of all waking up at the same instant and
+    colliding again.
+    """
+    capped = min(seconds, _MAX_WAIT)
+    return capped / 2 + random.uniform(0, capped / 2)
 
 
 def _key(method, path):
@@ -52,7 +65,7 @@ def wait_if_needed(method, path):
     candidates = [t for t in (cached[1] if cached else None, _shared_block(key)) if t]
     blocked_until = max(candidates, default=None)
     if blocked_until and blocked_until > time.time():
-        time.sleep(min(blocked_until - time.time(), _MAX_WAIT))
+        time.sleep(jittered_wait(blocked_until - time.time()))
 
 
 def note_blocked(method, path, retry_after):

--- a/src/cordless/webhook.py
+++ b/src/cordless/webhook.py
@@ -8,6 +8,7 @@ response path.
 
 import json
 import re
+import time
 from http.client import HTTPSConnection
 
 from ._multipart import build_multipart_body
@@ -49,17 +50,35 @@ def build_payload(content, embeds, components, *, username=None, avatar_url=None
 
 
 def _request(method, path, body=None, content_type=None):
-    conn = HTTPSConnection("discord.com", timeout=_TIMEOUT)
-    try:
-        headers = {"User-Agent": "cordless"}
-        if content_type is not None:
-            headers["Content-Type"] = content_type
-        conn.request(method, path, body, headers)
-        resp = conn.getresponse()
-        status = resp.status
-        data = resp.read()
-    finally:
-        conn.close()
+    """Make a webhooks/{id}/{token}/... call, retrying on 429 (honouring retry_after).
+
+    A webhook's id+token pair is its own credential and its own bucket, not
+    shared with anything else, so a local retry is all that's needed here.
+    """
+    headers = {"User-Agent": "cordless"}
+    if content_type is not None:
+        headers["Content-Type"] = content_type
+
+    status, data = 0, b""
+    for attempt in range(3):
+        conn = HTTPSConnection("discord.com", timeout=_TIMEOUT)
+        try:
+            conn.request(method, path, body, headers)
+            resp = conn.getresponse()
+            status = resp.status
+            data = resp.read()
+        finally:
+            conn.close()
+
+        if status == 429 and attempt < 2:
+            try:
+                retry_after = float(json.loads(data).get("retry_after", 1))
+            except (ValueError, AttributeError):
+                retry_after = 1.0
+            time.sleep(min(retry_after, 5))
+            continue
+        break
+
     if status >= 300:
         raise RuntimeError(f"Discord API error {status}: {data.decode(errors='replace')}")
     return status, data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ class FakeDiscordResponse:
 
     def __init__(self, payload):
         self._payload = payload
+        self.headers = {}
 
     def read(self):
         return json.dumps(self._payload).encode()

--- a/tests/test_app_features.py
+++ b/tests/test_app_features.py
@@ -669,6 +669,54 @@ def test_discord_request_retries_once_on_429_then_succeeds(monkeypatch):
     assert blocked == [0.2]
 
 
+def test_discord_request_rechecks_ratelimit_on_each_retry_attempt(monkeypatch):
+    """wait_if_needed must run before every attempt, not just the first - otherwise a
+    sibling call's note_blocked() from a moment ago is never consulted before retrying."""
+    import io
+    import os
+    import time
+    import urllib.error
+
+    import cordless.ratelimit as ratelimit
+
+    bot = Cordless()
+    waits = []
+    monkeypatch.setattr(ratelimit, "wait_if_needed", lambda method, path: waits.append((method, path)))
+    monkeypatch.setattr(ratelimit, "note_blocked", lambda method, path, retry_after: None)
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    class _Resp:
+        headers = {}
+
+        def __enter__(self_):
+            return self_
+
+        def __exit__(self_, *a):
+            return False
+
+        def read(self_):
+            return b"{}"
+
+    too_many_requests = urllib.error.HTTPError(
+        "url", 429, "rate limited", {}, io.BytesIO(json.dumps({"retry_after": 0.1}).encode())
+    )
+    responses = [too_many_requests, _Resp()]
+
+    def fake_urlopen(req):
+        resp = responses.pop(0)
+        if isinstance(resp, BaseException):
+            raise resp
+        return resp
+
+    with (
+        patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}),
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+    ):
+        bot._discord_request("POST", "/channels/123/messages", {"content": "hi"})
+
+    assert waits == [("POST", "/channels/123/messages"), ("POST", "/channels/123/messages")]
+
+
 def test_discord_request_gives_up_after_repeated_429(monkeypatch):
     import io
     import os

--- a/tests/test_app_features.py
+++ b/tests/test_app_features.py
@@ -717,7 +717,7 @@ def test_discord_request_rechecks_ratelimit_on_each_retry_attempt(monkeypatch):
     assert waits == [("POST", "/channels/123/messages"), ("POST", "/channels/123/messages")]
 
 
-def test_discord_request_gives_up_after_repeated_429(monkeypatch):
+def test_discord_request_gives_up_after_retry_budget_exhausted(monkeypatch):
     import io
     import os
     import time
@@ -725,6 +725,15 @@ def test_discord_request_gives_up_after_repeated_429(monkeypatch):
 
     bot = Cordless()
     monkeypatch.setattr(time, "sleep", lambda s: None)
+    # jump straight past _MAX_RETRY_SECONDS on the very first check, so this test
+    # doesn't actually spend 30 real seconds retrying against a mocked 429
+    clock = [0.0]
+
+    def fake_monotonic():
+        clock[0] += 100
+        return clock[0]
+
+    monkeypatch.setattr(time, "monotonic", fake_monotonic)
 
     def fake_urlopen(req):
         return (_ for _ in ()).throw(

--- a/tests/test_app_features.py
+++ b/tests/test_app_features.py
@@ -545,6 +545,8 @@ def test_discord_request_attaches_files_metadata_and_builds_multipart():
             def read(self_):
                 return b"{}"
 
+            headers = {}
+
         return _Resp()
 
     import os
@@ -559,6 +561,134 @@ def test_discord_request_attaches_files_metadata_and_builds_multipart():
     assert b'name="files[0]"; filename="board.png"' in captured["body"]
     assert b'name="payload_json"' in captured["body"]
     assert b'"attachments": [{"id": 0, "filename": "board.png"}]' in captured["body"]
+
+
+def test_discord_request_checks_ratelimit_before_sending(monkeypatch):
+    import cordless.ratelimit as ratelimit
+
+    bot = Cordless()
+    calls = []
+    monkeypatch.setattr(ratelimit, "wait_if_needed", lambda method, path: calls.append((method, path)))
+
+    class _Resp:
+        headers = {}
+
+        def __enter__(self_):
+            return self_
+
+        def __exit__(self_, *a):
+            return False
+
+        def read(self_):
+            return b"{}"
+
+    import os
+
+    with (
+        patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}),
+        patch("urllib.request.urlopen", return_value=_Resp()),
+    ):
+        bot._discord_request("POST", "/channels/123/messages", {"content": "hi"})
+
+    assert calls == [("POST", "/channels/123/messages")]
+
+
+def test_discord_request_records_response_headers_on_success(monkeypatch):
+    import cordless.ratelimit as ratelimit
+
+    bot = Cordless()
+    recorded = []
+    monkeypatch.setattr(ratelimit, "record_response", lambda method, path, headers: recorded.append(headers))
+
+    class _Resp:
+        headers = {"X-RateLimit-Remaining": "4", "X-RateLimit-Reset-After": "1"}
+
+        def __enter__(self_):
+            return self_
+
+        def __exit__(self_, *a):
+            return False
+
+        def read(self_):
+            return b"{}"
+
+    import os
+
+    with (
+        patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}),
+        patch("urllib.request.urlopen", return_value=_Resp()),
+    ):
+        bot._discord_request("POST", "/channels/123/messages", {"content": "hi"})
+
+    assert recorded == [_Resp.headers]
+
+
+def test_discord_request_retries_once_on_429_then_succeeds(monkeypatch):
+    import io
+    import os
+    import time
+    import urllib.error
+
+    import cordless.ratelimit as ratelimit
+
+    bot = Cordless()
+    blocked = []
+    monkeypatch.setattr(ratelimit, "note_blocked", lambda method, path, retry_after: blocked.append(retry_after))
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    class _Resp:
+        headers = {}
+
+        def __enter__(self_):
+            return self_
+
+        def __exit__(self_, *a):
+            return False
+
+        def read(self_):
+            return b"{}"
+
+    too_many_requests = urllib.error.HTTPError(
+        "url", 429, "rate limited", {}, io.BytesIO(json.dumps({"retry_after": 0.2}).encode())
+    )
+    responses = [too_many_requests, _Resp()]
+
+    def fake_urlopen(req):
+        resp = responses.pop(0)
+        if isinstance(resp, BaseException):
+            raise resp
+        return resp
+
+    with (
+        patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}),
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+    ):
+        result = bot._discord_request("POST", "/channels/123/messages", {"content": "hi"})
+
+    assert result == b"{}"
+    assert blocked == [0.2]
+
+
+def test_discord_request_gives_up_after_repeated_429(monkeypatch):
+    import io
+    import os
+    import time
+    import urllib.error
+
+    bot = Cordless()
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    def fake_urlopen(req):
+        return (_ for _ in ()).throw(
+            urllib.error.HTTPError("url", 429, "rate limited", {}, io.BytesIO(b'{"retry_after": 0.1}'))
+        )
+
+    with (
+        patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}),
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        pytest.raises(RuntimeError, match="429"),
+    ):
+        bot._discord_request("POST", "/channels/123/messages", {"content": "hi"})
 
 
 # --- load_extension ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -226,6 +226,14 @@ def test_destroy_prompt_aborts_on_no(tmp_path, monkeypatch):
     mock_destroy.assert_not_called()
 
 
+def test_destroy_passes_ratelimit_flag_from_config(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "cordless.toml").write_text('[deploy]\nfunction = "mybot"\nregion = "us-east-1"\nratelimit = true\n')
+    with patch("cordless.deploy.destroy") as mock_destroy:
+        main(["destroy", "--yes"])
+    assert mock_destroy.call_args.kwargs["ratelimit"] is True
+
+
 # ---------------------------------------------------------------------------
 # deploy arg->config precedence
 # ---------------------------------------------------------------------------
@@ -253,6 +261,22 @@ def test_deploy_falls_back_to_config(tmp_path, monkeypatch):
     kwargs = mock_deploy.call_args.kwargs
     assert kwargs["function_name"] == "from-toml"
     assert kwargs["region"] == "eu-west-1"
+
+
+def test_deploy_passes_ratelimit_flag_from_config(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "cordless.toml").write_text('[deploy]\nfunction = "mybot"\nregion = "us-east-1"\nratelimit = true\n')
+    with patch("cordless.deploy.deploy") as mock_deploy:
+        main(["deploy"])
+    assert mock_deploy.call_args.kwargs["ratelimit"] is True
+
+
+def test_deploy_ratelimit_defaults_to_false(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "cordless.toml").write_text('[deploy]\nfunction = "mybot"\nregion = "us-east-1"\n')
+    with patch("cordless.deploy.deploy") as mock_deploy:
+        main(["deploy"])
+    assert mock_deploy.call_args.kwargs["ratelimit"] is False
 
 
 def test_deploy_env_flag_overlays_dot_env(tmp_path, monkeypatch):

--- a/tests/test_defer.py
+++ b/tests/test_defer.py
@@ -190,6 +190,54 @@ def test_connection_has_timeout(fake_conn):
     assert fake_conn.requests[0]["timeout"] == cordless.defer._TIMEOUT
 
 
+# --- post_followup / delete_original retry (previously had none at all) ---
+
+
+def test_post_followup_retries_on_429_with_retry_after(fake_conn, monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(cordless.defer.time, "sleep", lambda s: sleeps.append(s))
+    fake_conn.responses = [(429, json.dumps({"retry_after": 0.4}).encode()), (200, b"{}")]
+
+    status, _ = cordless.defer.post_followup("app", "tok", {"content": "hi"})
+
+    assert status == 200
+    assert sleeps == [0.4]
+    assert len(fake_conn.requests) == 2
+
+
+def test_post_followup_does_not_retry_on_404(fake_conn, monkeypatch):
+    """Unlike @original, a new followup POST doesn't race Discord's ACK write,
+    so a 404 here is a real error, not worth retrying."""
+    monkeypatch.setattr(cordless.defer.time, "sleep", lambda s: None)
+    fake_conn.responses = [(404, b"{}")]
+
+    status, _ = cordless.defer.post_followup("app", "tok", {"content": "hi"})
+
+    assert status == 404
+    assert len(fake_conn.requests) == 1
+
+
+def test_delete_original_retries_on_404(fake_conn, monkeypatch):
+    monkeypatch.setattr(cordless.defer.time, "sleep", lambda s: None)
+    fake_conn.responses = [(404, b"{}"), (200, b"{}")]
+
+    status = cordless.defer.delete_original("app", "tok")
+
+    assert status == 200
+    assert len(fake_conn.requests) == 2
+
+
+def test_delete_original_retries_on_429(fake_conn, monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(cordless.defer.time, "sleep", lambda s: sleeps.append(s))
+    fake_conn.responses = [(429, json.dumps({"retry_after": 0.1}).encode()), (204, b"")]
+
+    status = cordless.defer.delete_original("app", "tok")
+
+    assert status == 204
+    assert sleeps == [0.1]
+
+
 # --- Crons ---
 
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -16,6 +16,8 @@ from cordless.deploy import (
     deploy,
     destroy,
     ensure_iam_role,
+    ensure_ratelimit_table,
+    ratelimit_table_name,
 )
 
 REGION = "us-east-1"
@@ -454,3 +456,105 @@ def test_destroy_removes_worker(deploy_patches, monkeypatch):
     lam = boto3.client("lambda", region_name=REGION)
     exists, _ = _function_exists(lam, "my-bot-worker")
     assert not exists
+
+
+# ---------------------------------------------------------------------------
+# Rate limit table
+# ---------------------------------------------------------------------------
+
+
+@mock_aws
+def test_ensure_ratelimit_table_creates_table():
+    dynamodb = boto3.client("dynamodb", region_name=REGION)
+    ensure_ratelimit_table(dynamodb, "my-bot-ratelimit")
+    assert dynamodb.describe_table(TableName="my-bot-ratelimit")["Table"]["TableStatus"] == "ACTIVE"
+
+
+@mock_aws
+def test_ensure_ratelimit_table_is_idempotent():
+    dynamodb = boto3.client("dynamodb", region_name=REGION)
+    ensure_ratelimit_table(dynamodb, "my-bot-ratelimit")
+    ensure_ratelimit_table(dynamodb, "my-bot-ratelimit")  # would raise if it tried to re-create
+
+
+@mock_aws
+def test_deploy_creates_ratelimit_table_when_enabled(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches, ratelimit=True))
+    dynamodb = boto3.client("dynamodb", region_name=REGION)
+    assert dynamodb.describe_table(TableName="my-bot-ratelimit")["Table"]["TableStatus"] == "ACTIVE"
+
+
+@mock_aws
+def test_deploy_skips_ratelimit_table_when_disabled(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches))
+    dynamodb = boto3.client("dynamodb", region_name=REGION)
+    with pytest.raises(dynamodb.exceptions.ResourceNotFoundException):
+        dynamodb.describe_table(TableName="my-bot-ratelimit")
+
+
+@mock_aws
+def test_deploy_sets_ratelimit_table_env_var(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches, ratelimit=True))
+    lam = boto3.client("lambda", region_name=REGION)
+    env_vars = lam.get_function_configuration(FunctionName="my-bot").get("Environment", {}).get("Variables", {})
+    assert env_vars.get("CORDLESS_RATELIMIT_TABLE") == "my-bot-ratelimit"
+
+
+@mock_aws
+def test_deploy_sets_ratelimit_table_env_var_on_worker_too(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches, ratelimit=True, defer_worker="my-bot-worker"))
+    lam = boto3.client("lambda", region_name=REGION)
+    env_vars = lam.get_function_configuration(FunctionName="my-bot-worker").get("Environment", {}).get("Variables", {})
+    assert env_vars.get("CORDLESS_RATELIMIT_TABLE") == "my-bot-ratelimit"
+
+
+@mock_aws
+def test_deploy_grants_ratelimit_table_access(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches, ratelimit=True))
+    policy = iam.get_role_policy(RoleName="my-bot-role", PolicyName="cordless-ratelimit-table")
+    assert "dynamodb:PutItem" in policy["PolicyDocument"]["Statement"][0]["Action"]
+
+
+@mock_aws
+def test_deploy_is_idempotent_with_ratelimit_enabled(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    kwargs = _base_deploy_kwargs(deploy_patches, ratelimit=True)
+    deploy(**kwargs)
+    deploy(**kwargs)  # would raise if the table create wasn't idempotent
+
+
+@mock_aws
+def test_destroy_removes_ratelimit_table(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches, ratelimit=True))
+    destroy("my-bot", "my-bot-role", REGION, ratelimit=True)
+    dynamodb = boto3.client("dynamodb", region_name=REGION)
+    with pytest.raises(dynamodb.exceptions.ResourceNotFoundException):
+        dynamodb.describe_table(TableName=ratelimit_table_name("my-bot"))
+
+
+@mock_aws
+def test_destroy_leaves_ratelimit_table_when_flag_omitted(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches, ratelimit=True))
+    destroy("my-bot", "my-bot-role", REGION)
+    dynamodb = boto3.client("dynamodb", region_name=REGION)
+    assert dynamodb.describe_table(TableName=ratelimit_table_name("my-bot"))["Table"]["TableStatus"] == "ACTIVE"
+
+
+@mock_aws
+def test_destroy_is_safe_when_ratelimit_table_never_existed():
+    destroy("my-bot", "my-bot-role", REGION, ratelimit=True)

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -77,6 +77,40 @@ def test_wait_if_needed_checks_dynamo_on_cold_start(monkeypatch):
     assert calls == ["POST /channels/1/messages"]
 
 
+def test_wait_if_needed_sleeps_on_local_state_even_if_shared_check_fails(monkeypatch):
+    """A local note_blocked() must still cause a wait even when DynamoDB is
+    unreachable/unconfigured and _shared_block fails open to None - otherwise
+    concurrent callers in the same process get zero benefit from each other's
+    429s whenever the shared table isn't actually working."""
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
+    import time
+
+    monkeypatch.setattr(ratelimit, "_shared_block", lambda key: None)
+    monkeypatch.setattr(ratelimit, "_put_shared", lambda key, blocked_until: None)
+    slept = []
+    monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+
+    ratelimit.note_blocked("POST", "/channels/1/messages", 0.3)
+    ratelimit.wait_if_needed("POST", "/channels/1/messages")
+
+    assert slept and slept[0] <= ratelimit._MAX_WAIT
+
+
+def test_wait_if_needed_prefers_the_later_of_local_and_shared_block(monkeypatch):
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
+    import time
+
+    now = time.time()
+    ratelimit._local["POST /channels/1/messages"] = (0, now + 0.1)
+    monkeypatch.setattr(ratelimit, "_shared_block", lambda key: now + 10)
+    slept = []
+    monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+
+    ratelimit.wait_if_needed("POST", "/channels/1/messages")
+
+    assert slept and slept[0] == pytest.approx(ratelimit._MAX_WAIT)
+
+
 def test_wait_if_needed_sleeps_until_shared_block_clears(monkeypatch):
     monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
     import time

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -65,6 +65,32 @@ def test_record_response_caches_remaining_and_reset(monkeypatch):
     assert reset_at > time.time()
 
 
+def test_record_response_publishes_to_shared_state_when_remaining_is_low(monkeypatch):
+    """A successful response revealing remaining=1 should warn siblings before
+    any of them has to burn its own 429 to find out the same thing."""
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
+    published = []
+    monkeypatch.setattr(ratelimit, "_put_shared", lambda key, blocked_until: published.append((key, blocked_until)))
+
+    ratelimit.record_response(
+        "POST", "/channels/1/messages", {"X-RateLimit-Remaining": "1", "X-RateLimit-Reset-After": "2.5"}
+    )
+
+    assert published and published[0][0] == "POST /channels/1/messages"
+
+
+def test_record_response_does_not_publish_when_remaining_is_comfortable(monkeypatch):
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
+    published = []
+    monkeypatch.setattr(ratelimit, "_put_shared", lambda key, blocked_until: published.append((key, blocked_until)))
+
+    ratelimit.record_response(
+        "POST", "/channels/1/messages", {"X-RateLimit-Remaining": "5", "X-RateLimit-Reset-After": "2.5"}
+    )
+
+    assert published == []
+
+
 def test_record_response_ignores_missing_headers(monkeypatch):
     monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
     ratelimit.record_response("POST", "/channels/1/messages", {})

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,6 +1,7 @@
 """Local header tracking + DynamoDB fallback for outbound rate-limit coordination."""
 
 import os
+import random
 
 import boto3
 import pytest
@@ -21,6 +22,18 @@ def _reset_local_cache():
     ratelimit._local.clear()
     yield
     ratelimit._local.clear()
+
+
+def test_jittered_wait_stays_within_half_to_full_of_the_capped_value():
+    for _ in range(200):
+        result = ratelimit.jittered_wait(2.0)
+        assert 1.0 <= result <= 2.0
+
+
+def test_jittered_wait_caps_at_max_wait_before_jittering():
+    for _ in range(200):
+        result = ratelimit.jittered_wait(100.0)
+        assert ratelimit._MAX_WAIT / 2 <= result <= ratelimit._MAX_WAIT
 
 
 def test_disabled_without_table_env_var(monkeypatch):
@@ -106,8 +119,12 @@ def test_wait_if_needed_prefers_the_later_of_local_and_shared_block(monkeypatch)
     slept = []
     monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
 
+    monkeypatch.setattr(random, "uniform", lambda a, b: b)  # deterministic: always the top of the jitter range
+
     ratelimit.wait_if_needed("POST", "/channels/1/messages")
 
+    # the shared block (now+10) wins over local (now+0.1), then gets capped at
+    # _MAX_WAIT before jitter is applied - so the full jittered range caps at _MAX_WAIT
     assert slept and slept[0] == pytest.approx(ratelimit._MAX_WAIT)
 
 

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -172,6 +172,36 @@ def test_shared_roundtrip_through_real_dynamo(dynamo_table):
     assert ratelimit._shared_block("POST /channels/2/messages") is None
 
 
+def test_shared_block_is_a_plain_float_not_decimal(dynamo_table):
+    """boto3's resource API deserializes DynamoDB Numbers as decimal.Decimal, which
+    blows up when wait_if_needed subtracts a float time.time() from it. Regression
+    test for that - assert the type, not just the value, so a mocked-only shared
+    return can't hide it again."""
+    import time
+
+    ratelimit._put_shared("POST /channels/1/messages", time.time() + 10)
+    result = ratelimit._shared_block("POST /channels/1/messages")
+    assert isinstance(result, float)
+    result - time.time()  # would raise TypeError if this were still a Decimal
+
+
+def test_wait_if_needed_works_end_to_end_against_real_dynamo(dynamo_table, monkeypatch):
+    """The actual bug: wait_if_needed's blocked_until - time.time() raised
+    TypeError against a real DynamoDB-backed table because _shared_block
+    returned a Decimal, never caught by tests that monkeypatched _shared_block
+    to return plain floats instead of exercising a real table round-trip."""
+    import time
+
+    monkeypatch.setattr(random, "uniform", lambda a, b: a)
+    slept = []
+    monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+
+    ratelimit._put_shared("POST /channels/1/messages", time.time() + 0.2)
+    ratelimit.wait_if_needed("POST", "/channels/1/messages")  # would raise TypeError pre-fix
+
+    assert slept
+
+
 def test_shared_block_fails_open_when_table_missing(monkeypatch):
     monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, "does-not-exist")
     with mock_aws():

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,0 +1,133 @@
+"""Local header tracking + DynamoDB fallback for outbound rate-limit coordination."""
+
+import os
+
+import boto3
+import pytest
+from moto import mock_aws
+
+import cordless.ratelimit as ratelimit
+
+REGION = "us-east-1"
+TABLE = "my-bot-ratelimit"
+
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+os.environ.setdefault("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture(autouse=True)
+def _reset_local_cache():
+    ratelimit._local.clear()
+    yield
+    ratelimit._local.clear()
+
+
+def test_disabled_without_table_env_var(monkeypatch):
+    monkeypatch.delenv(ratelimit._TABLE_ENV_VAR, raising=False)
+    assert ratelimit.enabled() is False
+
+
+def test_enabled_with_table_env_var(monkeypatch):
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
+    assert ratelimit.enabled() is True
+
+
+def test_record_response_noop_when_disabled(monkeypatch):
+    monkeypatch.delenv(ratelimit._TABLE_ENV_VAR, raising=False)
+    headers = {"X-RateLimit-Remaining": "0", "X-RateLimit-Reset-After": "5"}
+    ratelimit.record_response("POST", "/channels/1/messages", headers)
+    assert ratelimit._local == {}
+
+
+def test_record_response_caches_remaining_and_reset(monkeypatch):
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
+    ratelimit.record_response(
+        "POST", "/channels/1/messages", {"X-RateLimit-Remaining": "3", "X-RateLimit-Reset-After": "2.5"}
+    )
+    remaining, reset_at = ratelimit._local["POST /channels/1/messages"]
+    assert remaining == 3
+    import time
+
+    assert reset_at > time.time()
+
+
+def test_record_response_ignores_missing_headers(monkeypatch):
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
+    ratelimit.record_response("POST", "/channels/1/messages", {})
+    assert ratelimit._local == {}
+
+
+def test_wait_if_needed_skips_dynamo_when_locally_clear(monkeypatch):
+    """Plenty of remaining budget locally - never touches DynamoDB."""
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
+    monkeypatch.setattr(ratelimit, "_shared_block", lambda key: (_ for _ in ()).throw(AssertionError("should not run")))
+    ratelimit.record_response(
+        "POST", "/channels/1/messages", {"X-RateLimit-Remaining": "5", "X-RateLimit-Reset-After": "5"}
+    )
+    ratelimit.wait_if_needed("POST", "/channels/1/messages")  # would raise if it touched _shared_block
+
+
+def test_wait_if_needed_checks_dynamo_on_cold_start(monkeypatch):
+    """No local cache at all - has to ask the shared table."""
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
+    calls = []
+    monkeypatch.setattr(ratelimit, "_shared_block", lambda key: calls.append(key) or None)
+    ratelimit.wait_if_needed("POST", "/channels/1/messages")
+    assert calls == ["POST /channels/1/messages"]
+
+
+def test_wait_if_needed_sleeps_until_shared_block_clears(monkeypatch):
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
+    import time
+
+    monkeypatch.setattr(ratelimit, "_shared_block", lambda key: time.time() + 0.05)
+    slept = []
+    monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+    ratelimit.wait_if_needed("POST", "/channels/1/messages")
+    assert slept and slept[0] <= ratelimit._MAX_WAIT
+
+
+def test_note_blocked_writes_local_and_shared_state(monkeypatch):
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
+    written = []
+    monkeypatch.setattr(ratelimit, "_put_shared", lambda key, blocked_until: written.append((key, blocked_until)))
+    ratelimit.note_blocked("POST", "/channels/1/messages", 2.0)
+    assert ratelimit._local["POST /channels/1/messages"][0] == 0
+    assert written and written[0][0] == "POST /channels/1/messages"
+
+
+@pytest.fixture
+def dynamo_table(monkeypatch):
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, TABLE)
+    with mock_aws():
+        dynamodb = boto3.client("dynamodb", region_name=REGION)
+        dynamodb.create_table(
+            TableName=TABLE,
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        dynamodb.get_waiter("table_exists").wait(TableName=TABLE)
+        yield
+
+
+def test_shared_roundtrip_through_real_dynamo(dynamo_table):
+    import time
+
+    blocked_until = time.time() + 10
+    ratelimit._put_shared("POST /channels/1/messages", blocked_until)
+    assert ratelimit._shared_block("POST /channels/1/messages") == int(blocked_until) + 1
+    assert ratelimit._shared_block("POST /channels/2/messages") is None
+
+
+def test_shared_block_fails_open_when_table_missing(monkeypatch):
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, "does-not-exist")
+    with mock_aws():
+        assert ratelimit._shared_block("POST /channels/1/messages") is None
+
+
+def test_put_shared_fails_open_when_table_missing(monkeypatch):
+    monkeypatch.setenv(ratelimit._TABLE_ENV_VAR, "does-not-exist")
+    with mock_aws():
+        ratelimit._put_shared("POST /channels/1/messages", 123)  # should not raise

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -172,6 +172,28 @@ def test_non_2xx_status_raises(fake_conn):
         cordless.webhook.execute("123", "abc", {"content": "hi"})
 
 
+def test_execute_retries_on_429_with_retry_after(fake_conn, monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(cordless.webhook.time, "sleep", lambda s: sleeps.append(s))
+    fake_conn.responses = [(429, json.dumps({"retry_after": 0.4}).encode()), (200, b"{}")]
+
+    status, _ = cordless.webhook.execute("123", "abc", {"content": "hi"})
+
+    assert status == 200
+    assert sleeps == [0.4]
+    assert len(fake_conn.requests) == 2
+
+
+def test_execute_gives_up_after_retries(fake_conn, monkeypatch):
+    monkeypatch.setattr(cordless.webhook.time, "sleep", lambda s: None)
+    fake_conn.responses = [(429, b"{}"), (429, b"{}"), (429, b"{}")]
+
+    with pytest.raises(RuntimeError, match="Discord API error 429"):
+        cordless.webhook.execute("123", "abc", {"content": "hi"})
+
+    assert len(fake_conn.requests) == 3
+
+
 # --- Cordless.execute_webhook / edit_webhook_message / delete_webhook_message ---
 
 


### PR DESCRIPTION
## Changes

Adds optional rate limit handling for outbound Discord calls, plus retry coverage for a couple of code paths that had none.

By default, `send_message`/`edit_message`/`delete_message` now retry on 429 for up to 30 seconds, honoring `retry_after` with jitter. Setting `ratelimit = true` in `[deploy]` additionally provisions a small DynamoDB table so concurrent Lambda invocations can coordinate with each other instead of each retrying blind. This is opt in and off by default; no infrastructure is touched unless the flag is set.

Interaction followups (`patch_followup`, `post_followup`, `delete_original`) and webhook calls (`execute`, `edit_message`, `delete_message`) previously had partial or no retry logic. Both now retry on 429 locally. Neither participates in the DynamoDB coordination, since both are bucketed by their own token/credential and never share a bucket with another invocation, so there is nothing for cross-invocation coordination to do there.

## What's new?

- New `ratelimit.py`: local header tracking (`X-RateLimit-Remaining`/`Reset-After`) per warm container, with DynamoDB used only as a fallback when local state is missing or already close to the limit, not on every call.
- `app.py`: `_discord_request` retries on 429 with a real time budget instead of a fixed attempt count, and feeds the rate limit tracker.
- `deploy.py`/`cli.py`: `ratelimit = true` provisions a `PAY_PER_REQUEST` DynamoDB table with TTL, scopes an IAM policy to it, and threads the table name into both the main function and `defer_worker`. `destroy` tears it down symmetrically.
- `defer.py`: factored the existing retry loop out of `_patch` into a shared helper so `post_followup` and `delete_original` get the same 429/404 handling `patch_followup` already had.
- `webhook.py`: `execute`/`edit_message`/`delete_message` now retry on 429; previously any non-2xx response raised immediately.
- Several bug fixes found by testing against a real bot under real concurrent load: a Decimal-vs-float crash from DynamoDB's number type, `wait_if_needed` not actually using local state as a fallback when DynamoDB was unreachable, and thundering herd behavior from un-jittered retries.

## Known limitations

Cross-invocation coordination reduces collisions under concurrent load but does not eliminate them. A genuinely simultaneous burst across many cold invocations still produces some wasted 429s, since checking shared state before sending is inherently racy for truly simultaneous callers. Every 429 still resolves via the retry budget, nothing gets dropped, but there is real wasted latency under heavy concurrency. A strict per-call lock would close this gap but was deliberately not built, since it would tax every outbound call with a mandatory DynamoDB round trip instead of only the ones near a limit.

Coordination is also scoped per bucket (effectively per channel), not global. Discord's ~50 req/s global per-token limit is not tracked or protected against; only the per-bucket retry budget covers it.

Full write-up in the docs: https://cordless.dev/reference/ratelimiting/