### PR TITLE
perf: HTTP connection reuse, faster defaults, and Function URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ handler = bot.handler()
 
 ```bash
 cordless deploy --register
-# → https://abc123.execute-api.eu-west-2.amazonaws.com/
+# → https://abc123.lambda-url.us-east-1.on.aws/
 ```
 
 ---
@@ -26,7 +26,7 @@ cordless deploy --register
 
 Most Discord bots run as long-lived processes, a VPS or container that sits idle 99% of the time, waiting for someone to type a command. You pay for uptime whether your bot is busy or not.
 
-cordless flips this. Your bot is a Lambda function: it only runs when Discord sends an interaction, takes milliseconds to respond, and costs essentially nothing to host. One command provisions everything on AWS: IAM role, Lambda function, API Gateway endpoint and registers your commands with Discord.
+cordless flips this. Your bot is a Lambda function: it only runs when Discord sends an interaction, takes milliseconds to respond, and costs essentially nothing to host. One command provisions everything on AWS: IAM role, Lambda function, public endpoint (a direct Function URL by default, or API Gateway if you want a custom domain) and registers your commands with Discord.
 
 - **No server:** no EC2, no containers, no uptime monitoring, no SSH
 - **No idle cost:** Lambda charges per invocation, not per hour
@@ -72,7 +72,7 @@ cordless dev
 
 ```bash
 cordless deploy --register
-# → https://abc123.execute-api.eu-west-2.amazonaws.com/
+# → https://abc123.lambda-url.us-east-1.on.aws/
 ```
 
 Paste the URL into your Discord app's **Interactions Endpoint URL** and your bot is live.

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -442,7 +442,10 @@ class Cordless:
 
     def handler(self):
         def _handler(event, context=None):
-            cron_name = (event or {}).get("_cordless_cron")
+            event = event or {}
+            if event.get("_cordless_keepwarm"):
+                return None  # just here to keep the container warm, nothing to do
+            cron_name = event.get("_cordless_cron")
             if cron_name:
                 return self.run_cron(cron_name)
             return self.handle(event, context)

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -46,6 +46,7 @@ def _send_discord_request(method, path, body, headers):
             data = resp.read()
         return resp.status, resp.headers, data
 
+
 _OPTION_TYPES = {
     "string": 3,
     "integer": 4,

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -4,6 +4,8 @@ import inspect
 import json
 import os
 import re
+import threading
+from http.client import HTTPException, HTTPSConnection
 from typing import Literal, Union, get_args, get_origin
 
 from .context import _FLAG_UI_KIT, Context, _attach_files, _contains_uikit
@@ -19,6 +21,30 @@ PING = 1
 # main function's default 10s timeout should raise `timeout` in
 # cordless.toml or move the work behind defer_worker.
 _MAX_RETRY_SECONDS = 30.0
+
+# Kept open across invocations in a warm Lambda container, so most requests
+# skip the TLS handshake instead of paying for it every time.
+_conn = None
+_conn_lock = threading.Lock()
+
+
+def _send_discord_request(method, path, body, headers):
+    global _conn
+    with _conn_lock:
+        if _conn is None:
+            _conn = HTTPSConnection("discord.com")
+        try:
+            _conn.request(method, path, body, headers)
+            resp = _conn.getresponse()
+            data = resp.read()
+        except (HTTPException, OSError):
+            # the other end closed the kept-alive connection, reconnect once
+            _conn.close()
+            _conn = HTTPSConnection("discord.com")
+            _conn.request(method, path, body, headers)
+            resp = _conn.getresponse()
+            data = resp.read()
+        return resp.status, resp.headers, data
 
 _OPTION_TYPES = {
     "string": 3,
@@ -209,8 +235,6 @@ class Cordless:
     def _discord_request(self, method, path, payload=None, files=None):
         import json
         import time
-        import urllib.error
-        import urllib.request
         from importlib.metadata import version as _ver
 
         from . import ratelimit
@@ -231,27 +255,23 @@ class Cordless:
             **({"Content-Type": content_type} if content_type else {}),
         }
 
-        url = f"https://discord.com/api/v10{path}"
+        full_path = f"/api/v10{path}"
         deadline = time.monotonic() + _MAX_RETRY_SECONDS
         while True:
             ratelimit.wait_if_needed(method, path)
-            req = urllib.request.Request(url, data=body, headers=headers, method=method)
-            try:
-                with urllib.request.urlopen(req) as resp:
-                    data = resp.read()
-                    ratelimit.record_response(method, path, resp.headers)
-                    return data
-            except urllib.error.HTTPError as exc:
-                body_out = exc.read()
-                if exc.code == 429 and time.monotonic() < deadline:
-                    try:
-                        retry_after = float(json.loads(body_out).get("retry_after", 1))
-                    except (ValueError, AttributeError):
-                        retry_after = 1.0
-                    ratelimit.note_blocked(method, path, retry_after)
-                    time.sleep(ratelimit.jittered_wait(retry_after))
-                    continue
-                raise RuntimeError(f"Discord API error {exc.code}: {body_out.decode(errors='replace')}") from exc
+            status, resp_headers, data = _send_discord_request(method, full_path, body, headers)
+            if status < 300:
+                ratelimit.record_response(method, path, resp_headers)
+                return data
+            if status == 429 and time.monotonic() < deadline:
+                try:
+                    retry_after = float(json.loads(data).get("retry_after", 1))
+                except (ValueError, AttributeError):
+                    retry_after = 1.0
+                ratelimit.note_blocked(method, path, retry_after)
+                time.sleep(ratelimit.jittered_wait(retry_after))
+                continue
+            raise RuntimeError(f"Discord API error {status}: {data.decode(errors='replace')}")
 
     async def send_message(self, channel_id, content=None, *, embeds=None, components=None, files=None):
         payload = {}

--- a/src/cordless/cli.py
+++ b/src/cordless/cli.py
@@ -215,7 +215,7 @@ def _deploy(args):
         defer_memory=int(cfg.get("defer_memory", 256)),
         policies=cfg.get("policies"),
         crons=crons,
-        architecture=args.architecture or cfg.get("architecture", "x86_64"),
+        architecture=args.architecture or cfg.get("architecture"),
         ratelimit=bool(cfg.get("ratelimit", False)),
     )
 
@@ -571,7 +571,10 @@ def main(argv=None):
         "--defer-timeout", metavar="SECONDS", default=None, help="Worker Lambda timeout in seconds (default: 30)"
     )
     deploy_cmd.add_argument(
-        "--architecture", default=None, choices=["x86_64", "arm64"], help="Lambda architecture (default: x86_64)"
+        "--architecture",
+        default=None,
+        choices=["x86_64", "arm64"],
+        help="Lambda architecture (default: arm64 for a new function, unchanged for an existing one)",
     )
     deploy_cmd.add_argument(
         "--verbose",

--- a/src/cordless/cli.py
+++ b/src/cordless/cli.py
@@ -302,7 +302,9 @@ _INIT_TOML = """\
 [deploy]
 function = "{name}"
 endpoint = "{endpoint}"
-# region = "eu-west-2"
+# us-east-1 is closest to Discord's own API infrastructure - EU-hosted bots
+# typically see ~140-160ms to Discord's API, US-hosted ~20-30ms
+region = "us-east-1"
 """
 
 _INIT_ENV = """\

--- a/src/cordless/cli.py
+++ b/src/cordless/cli.py
@@ -218,6 +218,7 @@ def _deploy(args):
         architecture=args.architecture or cfg.get("architecture"),
         ratelimit=bool(cfg.get("ratelimit", False)),
         endpoint=args.endpoint or cfg.get("endpoint"),
+        keep_warm=cfg.get("keep-warm"),
     )
 
     if args.register:

--- a/src/cordless/cli.py
+++ b/src/cordless/cli.py
@@ -217,6 +217,7 @@ def _deploy(args):
         crons=crons,
         architecture=args.architecture or cfg.get("architecture"),
         ratelimit=bool(cfg.get("ratelimit", False)),
+        endpoint=args.endpoint or cfg.get("endpoint"),
     )
 
     if args.register:
@@ -262,7 +263,7 @@ def _destroy(args):
         targets = f"function '{function_name}'" + (f", worker '{defer_worker}'" if defer_worker else "")
         if layer_name:
             targets += f", layer '{layer_name}'"
-        answer = input(f"Delete {targets}, its API Gateway, logs, and role '{role_name}'? [y/N] ")
+        answer = input(f"Delete {targets}, its API Gateway/Function URL, logs, and role '{role_name}'? [y/N] ")
         if answer.strip().lower() not in ("y", "yes"):
             raise SystemExit("Aborted.")
 
@@ -299,6 +300,7 @@ handler = bot.handler()
 _INIT_TOML = """\
 [deploy]
 function = "{name}"
+endpoint = "{endpoint}"
 # region = "eu-west-2"
 """
 
@@ -312,12 +314,48 @@ DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
 """
 
+_ENDPOINT_EXPLANATION = """
+How should Discord reach your bot? Pick one:
+
+  1. function_url  (recommended) - A direct Lambda Function URL. Fewer
+     moving parts and lower latency: no separate service sits between
+     Discord and your function. The trade-off is you can't attach a
+     custom domain directly - you'd get a raw *.lambda-url.<region>.on.aws
+     address, or you'd need to put something like CloudFront in front of
+     it yourself if you want your own domain.
+
+  2. api_gateway - Routes through an API Gateway HTTP API in front of your
+     function. Slightly more moving parts and a small extra network hop,
+     but it's the option that supports attaching a custom domain directly.
+"""
+
+
+def _prompt_endpoint():
+    print(_ENDPOINT_EXPLANATION)
+    while True:
+        answer = input("Choose [1=function_url / 2=api_gateway]: ").strip().lower()
+        if answer in ("1", "function_url"):
+            return "function_url"
+        if answer in ("2", "api_gateway"):
+            return "api_gateway"
+        print("  Please enter 1 or 2.")
+
 
 def _init(args):
     name = args.name or os.path.basename(os.getcwd())
+
+    endpoint = args.endpoint
+    if endpoint is None:
+        if not sys.stdin.isatty():
+            raise SystemExit(
+                "cordless init needs an endpoint choice and isn't running interactively: "
+                "pass --endpoint api_gateway|function_url."
+            )
+        endpoint = _prompt_endpoint()
+
     files = {
         "lambda_function.py": _INIT_LAMBDA,
-        "cordless.toml": _INIT_TOML.format(name=name),
+        "cordless.toml": _INIT_TOML.format(name=name, endpoint=endpoint),
         ".env.example": _INIT_ENV,
     }
     for fname, content in files.items():
@@ -577,6 +615,16 @@ def main(argv=None):
         help="Lambda architecture (default: arm64 for a new function, unchanged for an existing one)",
     )
     deploy_cmd.add_argument(
+        "--endpoint",
+        default=None,
+        choices=["api_gateway", "function_url"],
+        help=(
+            "How Discord reaches the function: a direct Lambda Function URL, or an "
+            "API Gateway HTTP API in front of it (needed for a custom domain). "
+            "Default: function_url for a new function, unchanged for an existing one"
+        ),
+    )
+    deploy_cmd.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -597,7 +645,7 @@ def main(argv=None):
     # destroy
     destroy_cmd = subparsers.add_parser(
         "destroy",
-        help="Delete the Lambda function(s), API Gateway, cron rules, logs, and IAM role for a deployed bot",
+        help="Delete the Lambda function(s), endpoint, cron rules, logs, and IAM role for a deployed bot",
         allow_abbrev=False,
     )
     destroy_cmd.add_argument(
@@ -628,6 +676,12 @@ def main(argv=None):
         "init", help="Scaffold a new cordless bot in the current directory", allow_abbrev=False
     )
     init_cmd.add_argument("name", nargs="?", default=None, help="Function name (default: current directory name)")
+    init_cmd.add_argument(
+        "--endpoint",
+        default=None,
+        choices=["api_gateway", "function_url"],
+        help="Skip the interactive prompt and use this endpoint type",
+    )
     init_cmd.set_defaults(func=_init)
 
     # dev

--- a/src/cordless/defer.py
+++ b/src/cordless/defer.py
@@ -1,10 +1,34 @@
 """Deferred interaction support: async Lambda invoke and Discord followup webhook."""
 
 import json
+import threading
 import time
-from http.client import HTTPSConnection
+from http.client import HTTPException, HTTPSConnection
 
 _TIMEOUT = 10
+
+# Kept open across invocations in a warm Lambda container, so most requests
+# skip the TLS handshake instead of paying for it every time.
+_conn = None
+_conn_lock = threading.Lock()
+
+
+def _send(method, path, body, headers):
+    global _conn
+    with _conn_lock:
+        if _conn is None:
+            _conn = HTTPSConnection("discord.com", timeout=_TIMEOUT)
+        try:
+            _conn.request(method, path, body, headers)
+            resp = _conn.getresponse()
+            return resp.status, resp.read()
+        except (HTTPException, OSError):
+            # the other end closed the kept-alive connection, reconnect once
+            _conn.close()
+            _conn = HTTPSConnection("discord.com", timeout=_TIMEOUT)
+            _conn.request(method, path, body, headers)
+            resp = _conn.getresponse()
+            return resp.status, resp.read()
 
 # Pre-create the Lambda client at import time so cold-start invocations don't
 # pay the boto3 initialisation cost inside Discord's 3-second response window.
@@ -60,14 +84,7 @@ def _request(method, path, body=None, content_type=None, retry_404=False):
 
     status, body_out = 0, b""
     for attempt in range(3):
-        conn = HTTPSConnection("discord.com", timeout=_TIMEOUT)
-        try:
-            conn.request(method, path, body, headers)
-            resp = conn.getresponse()
-            status = resp.status
-            body_out = resp.read()
-        finally:
-            conn.close()
+        status, body_out = _send(method, path, body, headers)
 
         if status == 404 and retry_404 and attempt < 2:
             time.sleep(0.5)

--- a/src/cordless/defer.py
+++ b/src/cordless/defer.py
@@ -30,6 +30,7 @@ def _send(method, path, body, headers):
             resp = _conn.getresponse()
             return resp.status, resp.read()
 
+
 # Pre-create the Lambda client at import time so cold-start invocations don't
 # pay the boto3 initialisation cost inside Discord's 3-second response window.
 try:

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -437,10 +437,16 @@ def _ensure_function_url(lam, function_name):
     it ever reaches the handler, which is exactly what silently breaks
     Discord's endpoint verification (it never gets any response to sign
     against, just a flat rejection).
+
+    Both add_permission calls run every time, even when the URL config
+    already exists - not just on first creation. A function whose URL was
+    created by an older cordless version (or a partially failed earlier
+    attempt) may already have the config but be missing one or both
+    permission statements; returning early here would leave it stuck
+    broken instead of healing it on the next deploy.
     """
     try:
         config = lam.get_function_url_config(FunctionName=function_name)
-        return config["FunctionUrl"]
     except lam.exceptions.ResourceNotFoundException:
         config = lam.create_function_url_config(FunctionName=function_name, AuthType="NONE")
 

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -69,6 +69,7 @@ _KNOWN_DEPLOY_KEYS = {
     "policies",
     "architecture",
     "ratelimit",
+    "endpoint",
 }
 
 
@@ -411,6 +412,63 @@ def _ensure_api_gateway(apigw, lam, function_name, function_arn, region, account
     return endpoint
 
 
+def _has_api_gateway(apigw, function_name):
+    api_name = f"{function_name}-api"
+    return any(a["Name"] == api_name for a in _list_all_apis(apigw))
+
+
+def _has_function_url(lam, function_name):
+    try:
+        lam.get_function_url_config(FunctionName=function_name)
+        return True
+    except lam.exceptions.ResourceNotFoundException:
+        return False
+
+
+def _ensure_function_url(lam, function_name):
+    """Like _ensure_api_gateway, but a direct Lambda Function URL - no API
+    Gateway hop, no separate service to provision or tear down (deleting the
+    function removes its Function URL along with it).
+
+    A public (AuthType=NONE) function URL needs two resource-policy
+    statements, not one: lambda:InvokeFunctionUrl, and - required by AWS
+    since October 2025 - a second lambda:InvokeFunction statement gated on
+    InvokedViaFunctionUrl. Without the second one every request 403s before
+    it ever reaches the handler, which is exactly what silently breaks
+    Discord's endpoint verification (it never gets any response to sign
+    against, just a flat rejection).
+    """
+    try:
+        config = lam.get_function_url_config(FunctionName=function_name)
+        return config["FunctionUrl"]
+    except lam.exceptions.ResourceNotFoundException:
+        config = lam.create_function_url_config(FunctionName=function_name, AuthType="NONE")
+
+    try:
+        lam.add_permission(
+            FunctionName=function_name,
+            StatementId="FunctionURLAllowPublicAccess",
+            Action="lambda:InvokeFunctionUrl",
+            Principal="*",
+            FunctionUrlAuthType="NONE",
+        )
+    except lam.exceptions.ResourceConflictException:
+        pass
+
+    try:
+        lam.add_permission(
+            FunctionName=function_name,
+            StatementId="FunctionURLInvokeAllowPublicAccess",
+            Action="lambda:InvokeFunction",
+            Principal="*",
+            InvokedViaFunctionUrl=True,
+        )
+    except lam.exceptions.ResourceConflictException:
+        pass
+
+    return config["FunctionUrl"]
+
+
 def _allow_worker_invoke(iam, role_name, worker_arn):
     iam.put_role_policy(
         RoleName=role_name,
@@ -495,6 +553,7 @@ def deploy(
     crons=None,
     architecture=None,
     ratelimit=False,
+    endpoint=None,
 ):
     if not function_name:
         raise SystemExit("Function name is required: pass --function or set [deploy] function in cordless.toml")
@@ -518,6 +577,16 @@ def deploy(
             architecture = existing_config.get("Architectures", ["x86_64"])[0]
         except lam.exceptions.ResourceNotFoundException:
             architecture = "arm64"
+
+    if endpoint is None:
+        # keep whichever endpoint an existing function already has; only a
+        # brand new function gets the simpler, lower-latency default
+        if _has_function_url(lam, function_name):
+            endpoint = "function_url"
+        elif _has_api_gateway(apigw, function_name):
+            endpoint = "api_gateway"
+        else:
+            endpoint = "function_url"
 
     print()
 
@@ -589,8 +658,12 @@ def deploy(
                     architecture=architecture,
                 )
 
-        with Spinner("API Gateway"):
-            url = _ensure_api_gateway(apigw, lam, function_name, function_arn, region, account_id)
+        if endpoint == "function_url":
+            with Spinner("function URL"):
+                url = _ensure_function_url(lam, function_name)
+        else:
+            with Spinner("API Gateway"):
+                url = _ensure_api_gateway(apigw, lam, function_name, function_arn, region, account_id)
 
         if defer_worker:
             w_exists, worker_arn = _function_exists(lam, defer_worker)

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -70,7 +70,10 @@ _KNOWN_DEPLOY_KEYS = {
     "architecture",
     "ratelimit",
     "endpoint",
+    "keep-warm",
 }
+
+_DEFAULT_KEEPWARM_SCHEDULE = "rate(5 minutes)"
 
 
 def load_config(source_dir):
@@ -560,6 +563,7 @@ def deploy(
     architecture=None,
     ratelimit=False,
     endpoint=None,
+    keep_warm=None,
 ):
     if not function_name:
         raise SystemExit("Function name is required: pass --function or set [deploy] function in cordless.toml")
@@ -724,6 +728,9 @@ def deploy(
         with Spinner(f"cron schedules ({len(crons)})"):
             _wire_crons(events, lam, function_name, cron_target, cron_arn, crons)
 
+    with Spinner("keep-warm"):
+        _wire_keepwarm(session.client("events"), lam, function_name, function_arn, keep_warm)
+
     success(url)
     return url
 
@@ -780,6 +787,60 @@ def _wire_crons(events, lam, function_name, target_fn, target_arn, crons):
         )
 
 
+def _keepwarm_schedule(keep_warm):
+    if keep_warm is True:
+        return _DEFAULT_KEEPWARM_SCHEDULE
+    if isinstance(keep_warm, str):
+        return keep_warm
+    return None
+
+
+def _wire_keepwarm(events, lam, function_name, function_arn, keep_warm):
+    """Ping the main function directly on a schedule so it doesn't go cold
+    between real invocations. Always targets the main function, never the
+    worker - regular crons can't do this, since they all share one target
+    (defer_worker if it's set, otherwise the main function)."""
+    schedule = _keepwarm_schedule(keep_warm)
+    if not schedule:
+        _remove_keepwarm(events, lam, function_name)
+        return
+
+    rule_name = f"{function_name}-keepwarm"
+    statement_id = "cordless-keepwarm"
+    rule_arn = events.put_rule(Name=rule_name, ScheduleExpression=schedule)["RuleArn"]
+    events.put_targets(
+        Rule=rule_name,
+        Targets=[{"Id": "cordless", "Arn": function_arn, "Input": json.dumps({"_cordless_keepwarm": True})}],
+    )
+    try:
+        lam.remove_permission(FunctionName=function_name, StatementId=statement_id)
+    except lam.exceptions.ResourceNotFoundException:
+        pass
+    lam.add_permission(
+        FunctionName=function_name,
+        StatementId=statement_id,
+        Action="lambda:InvokeFunction",
+        Principal="events.amazonaws.com",
+        SourceArn=rule_arn,
+    )
+
+
+def _remove_keepwarm(events, lam, function_name):
+    rule_name = f"{function_name}-keepwarm"
+    try:
+        targets = events.list_targets_by_rule(Rule=rule_name).get("Targets", [])
+    except events.exceptions.ResourceNotFoundException:
+        return
+    target_ids = [t["Id"] for t in targets]
+    if target_ids:
+        events.remove_targets(Rule=rule_name, Ids=target_ids)
+    events.delete_rule(Name=rule_name)
+    try:
+        lam.remove_permission(FunctionName=function_name, StatementId="cordless-keepwarm")
+    except lam.exceptions.ResourceNotFoundException:
+        pass
+
+
 def destroy(function_name, role_name, region, defer_worker=None, layer_name=None, ratelimit=False):
     if not function_name:
         raise SystemExit("Function name is required: pass --function or set [deploy] function in cordless.toml")
@@ -810,6 +871,9 @@ def destroy(function_name, role_name, region, defer_worker=None, layer_name=None
             if target_ids:
                 events.remove_targets(Rule=rule["Name"], Ids=target_ids)
             events.delete_rule(Name=rule["Name"])
+
+    with Spinner("keep-warm"):
+        _remove_keepwarm(events, lam, function_name)
 
     for fn in [function_name] + ([defer_worker] if defer_worker else []):
         with Spinner(f"Lambda  {fn}"):

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -87,6 +87,17 @@ def load_config(source_dir):
 def build_function_zip(source_dir, bundle_cordless=False, packages=None, python_version="3.12", architecture="x86_64"):
     tmp = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
     tmp.close()
+    # pynacl (bundle_cordless extras) and a user's own `packages = ["pynacl"]`
+    # can resolve to the same cache dir, so this dedupes to avoid writing the
+    # same file into the zip twice
+    written = set()
+
+    def _write(zf, abs_path, arcname):
+        if arcname in written:
+            return
+        written.add(arcname)
+        zf.write(abs_path, arcname)
+
     with zipfile.ZipFile(tmp.name, "w", zipfile.ZIP_DEFLATED) as zf:
         for root, dirs, files in os.walk(source_dir):
             dirs[:] = [d for d in dirs if not _exclude_dir(d)]
@@ -94,7 +105,7 @@ def build_function_zip(source_dir, bundle_cordless=False, packages=None, python_
                 if _exclude_file(fname):
                     continue
                 abs_path = os.path.join(root, fname)
-                zf.write(abs_path, os.path.relpath(abs_path, source_dir))
+                _write(zf, abs_path, os.path.relpath(abs_path, source_dir))
 
         if bundle_cordless:
             from .upload import _cordless_package_dir, _layer_extras_dir
@@ -107,7 +118,7 @@ def build_function_zip(source_dir, bundle_cordless=False, packages=None, python_
                     if fname.endswith(".pyc"):
                         continue
                     abs_path = os.path.join(root, fname)
-                    zf.write(abs_path, os.path.relpath(abs_path, pkg_parent))
+                    _write(zf, abs_path, os.path.relpath(abs_path, pkg_parent))
             # include dist-info/egg-info so importlib.metadata works inside Lambda
             import glob
 
@@ -116,7 +127,7 @@ def build_function_zip(source_dir, bundle_cordless=False, packages=None, python_
                     for root, dirs, files in os.walk(dist_info):
                         for fname in files:
                             abs_path = os.path.join(root, fname)
-                            zf.write(abs_path, os.path.relpath(abs_path, pkg_parent))
+                            _write(zf, abs_path, os.path.relpath(abs_path, pkg_parent))
 
             # same pynacl bundling the layer path gets, so bundle_cordless doesn't
             # silently fall back to slow signature verification
@@ -128,7 +139,7 @@ def build_function_zip(source_dir, bundle_cordless=False, packages=None, python_
                         if fname.endswith(".pyc"):
                             continue
                         abs_path = os.path.join(root, fname)
-                        zf.write(abs_path, os.path.relpath(abs_path, extras_dir))
+                        _write(zf, abs_path, os.path.relpath(abs_path, extras_dir))
         if packages:
             pkg_dir = _ensure_packages(packages, python_version, architecture)
             for root, dirs, files in os.walk(pkg_dir):
@@ -137,7 +148,7 @@ def build_function_zip(source_dir, bundle_cordless=False, packages=None, python_
                     if fname.endswith(".pyc"):
                         continue
                     abs_path = os.path.join(root, fname)
-                    zf.write(abs_path, os.path.relpath(abs_path, pkg_dir))
+                    _write(zf, abs_path, os.path.relpath(abs_path, pkg_dir))
 
     return tmp.name
 

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -511,6 +511,10 @@ def deploy(
             _allow_ratelimit_table(iam, role_name, table_arn)
         env = {**env, "CORDLESS_RATELIMIT_TABLE": table_name}
 
+    from . import upload as _upload
+
+    _upload.pynacl_bundle_failed = False
+
     if bundle_cordless:
         with Spinner(f"cordless  {_cordless_version()} (local)"):
             layer_arn = None
@@ -526,6 +530,11 @@ def deploy(
             python_version=python_version,
             architecture=architecture,
         )
+
+    # printed after both spinners above have stopped animating, so it can't
+    # get overwritten by their mid-spin redraws
+    if _upload.pynacl_bundle_failed:
+        print("  cordless: could not bundle pynacl, using the slower pure-Python signature verification")
 
     try:
         exists, function_arn = _function_exists(lam, function_name)

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -493,7 +493,7 @@ def deploy(
     defer_memory=256,
     policies=None,
     crons=None,
-    architecture="x86_64",
+    architecture=None,
     ratelimit=False,
 ):
     if not function_name:
@@ -508,6 +508,16 @@ def deploy(
     lam = session.client("lambda")
     apigw = session.client("apigatewayv2")
     account_id = session.client("sts").get_caller_identity()["Account"]
+
+    if architecture is None:
+        # AWS won't let an existing function's architecture change in place, so
+        # an unset architecture keeps whatever's already deployed. arm64 is only
+        # the default for a function that doesn't exist yet.
+        try:
+            existing_config = lam.get_function_configuration(FunctionName=function_name)
+            architecture = existing_config.get("Architectures", ["x86_64"])[0]
+        except lam.exceptions.ResourceNotFoundException:
+            architecture = "arm64"
 
     print()
 

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -97,7 +97,7 @@ def build_function_zip(source_dir, bundle_cordless=False, packages=None, python_
                 zf.write(abs_path, os.path.relpath(abs_path, source_dir))
 
         if bundle_cordless:
-            from .upload import _cordless_package_dir
+            from .upload import _cordless_package_dir, _layer_extras_dir
 
             pkg_dir = _cordless_package_dir()
             pkg_parent = os.path.dirname(pkg_dir)
@@ -117,6 +117,18 @@ def build_function_zip(source_dir, bundle_cordless=False, packages=None, python_
                         for fname in files:
                             abs_path = os.path.join(root, fname)
                             zf.write(abs_path, os.path.relpath(abs_path, pkg_parent))
+
+            # same pynacl bundling the layer path gets, so bundle_cordless doesn't
+            # silently fall back to slow signature verification
+            extras_dir = _layer_extras_dir(python_version, architecture)
+            if extras_dir:
+                for root, dirs, files in os.walk(extras_dir):
+                    dirs[:] = [d for d in dirs if d != "__pycache__"]
+                    for fname in files:
+                        if fname.endswith(".pyc"):
+                            continue
+                        abs_path = os.path.join(root, fname)
+                        zf.write(abs_path, os.path.relpath(abs_path, extras_dir))
         if packages:
             pkg_dir = _ensure_packages(packages, python_version, architecture)
             for root, dirs, files in os.walk(pkg_dir):

--- a/src/cordless/ratelimit.py
+++ b/src/cordless/ratelimit.py
@@ -85,10 +85,18 @@ def note_blocked(method, path, retry_after):
     _put_shared(key, blocked_until)
 
 
-def _table():
-    import boto3
+_tables = {}
 
-    return boto3.resource("dynamodb").Table(os.environ[_TABLE_ENV_VAR])
+
+def _table():
+    name = os.environ[_TABLE_ENV_VAR]
+    table = _tables.get(name)
+    if table is None:
+        import boto3
+
+        table = boto3.resource("dynamodb").Table(name)
+        _tables[name] = table
+    return table
 
 
 def _shared_block(key):

--- a/src/cordless/upload.py
+++ b/src/cordless/upload.py
@@ -13,15 +13,21 @@ def _cordless_package_dir():
     return os.path.dirname(spec.origin)
 
 
+# Set when a fetch fails, so deploy() can warn once the spinner has stopped
+# animating instead of mid-spin, where print() gets stomped by its redraws.
+pynacl_bundle_failed = False
+
+
 def _layer_extras_dir(python_version, architecture="x86_64"):
     """Fetch pynacl (fast Ed25519 verify) for the layer. Never fails the deploy -
     falls back to the pure-Python verify path if the fetch doesn't work out."""
+    global pynacl_bundle_failed
     from .deploy import _ensure_packages
 
     try:
         return _ensure_packages(["pynacl"], python_version, architecture)
-    except Exception as exc:
-        print(f"cordless: could not bundle pynacl ({exc}), falling back to pure-Python signature verification")
+    except Exception:
+        pynacl_bundle_failed = True
         return None
 
 

--- a/src/cordless/upload.py
+++ b/src/cordless/upload.py
@@ -14,10 +14,15 @@ def _cordless_package_dir():
 
 
 def _layer_extras_dir(python_version, architecture="x86_64"):
-    """Fetch pynacl (fast Ed25519 verify) for the layer."""
+    """Fetch pynacl (fast Ed25519 verify) for the layer. Never fails the deploy -
+    falls back to the pure-Python verify path if the fetch doesn't work out."""
     from .deploy import _ensure_packages
 
-    return _ensure_packages(["pynacl"], python_version, architecture)
+    try:
+        return _ensure_packages(["pynacl"], python_version, architecture)
+    except Exception as exc:
+        print(f"cordless: could not bundle pynacl ({exc}), falling back to pure-Python signature verification")
+        return None
 
 
 def build_layer_zip(python_version=None, architecture="x86_64"):

--- a/src/cordless/upload.py
+++ b/src/cordless/upload.py
@@ -38,6 +38,16 @@ def build_layer_zip(python_version=None, architecture="x86_64"):
 
     tmp = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
     tmp.close()
+    # cordless's own files and the pynacl extras can overlap (e.g. a stray
+    # dotfile at the root of both trees), so dedupe to avoid writing the same
+    # zip entry twice
+    written = set()
+
+    def _write(zf, abs_path, arcname):
+        if arcname in written:
+            return
+        written.add(arcname)
+        zf.write(abs_path, arcname)
 
     with zipfile.ZipFile(tmp.name, "w", zipfile.ZIP_DEFLATED) as zf:
         for root, dirs, files in os.walk(pkg_dir):
@@ -47,7 +57,7 @@ def build_layer_zip(python_version=None, architecture="x86_64"):
                     continue
                 abs_path = os.path.join(root, fname)
                 rel_path = os.path.relpath(abs_path, site_dir)
-                zf.write(abs_path, os.path.join("python", rel_path))
+                _write(zf, abs_path, os.path.join("python", rel_path))
 
         import glob
 
@@ -57,7 +67,7 @@ def build_layer_zip(python_version=None, architecture="x86_64"):
                     for fname in files:
                         abs_path = os.path.join(root, fname)
                         rel_path = os.path.relpath(abs_path, site_dir)
-                        zf.write(abs_path, os.path.join("python", rel_path))
+                        _write(zf, abs_path, os.path.join("python", rel_path))
 
         extras_dir = _layer_extras_dir(python_version, architecture) if python_version else None
         if extras_dir:
@@ -68,7 +78,7 @@ def build_layer_zip(python_version=None, architecture="x86_64"):
                         continue
                     abs_path = os.path.join(root, fname)
                     rel_path = os.path.relpath(abs_path, extras_dir)
-                    zf.write(abs_path, os.path.join("python", rel_path))
+                    _write(zf, abs_path, os.path.join("python", rel_path))
 
     return tmp.name
 

--- a/src/cordless/webhook.py
+++ b/src/cordless/webhook.py
@@ -8,8 +8,9 @@ response path.
 
 import json
 import re
+import threading
 import time
-from http.client import HTTPSConnection
+from http.client import HTTPException, HTTPSConnection
 
 from ._multipart import build_multipart_body
 from .context import _FLAG_UI_KIT, _attach_files, _contains_uikit
@@ -17,6 +18,29 @@ from .context import _FLAG_UI_KIT, _attach_files, _contains_uikit
 _TIMEOUT = 10
 
 _URL_RE = re.compile(r"discord(?:app)?\.com/api(?:/v\d+)?/webhooks/(\d+)/([\w-]+)")
+
+# Kept open across invocations in a warm Lambda container, so most requests
+# skip the TLS handshake instead of paying for it every time.
+_conn = None
+_conn_lock = threading.Lock()
+
+
+def _send(method, path, body, headers):
+    global _conn
+    with _conn_lock:
+        if _conn is None:
+            _conn = HTTPSConnection("discord.com", timeout=_TIMEOUT)
+        try:
+            _conn.request(method, path, body, headers)
+            resp = _conn.getresponse()
+            return resp.status, resp.read()
+        except (HTTPException, OSError):
+            # the other end closed the kept-alive connection, reconnect once
+            _conn.close()
+            _conn = HTTPSConnection("discord.com", timeout=_TIMEOUT)
+            _conn.request(method, path, body, headers)
+            resp = _conn.getresponse()
+            return resp.status, resp.read()
 
 
 def parse_webhook_url(url):
@@ -61,14 +85,7 @@ def _request(method, path, body=None, content_type=None):
 
     status, data = 0, b""
     for attempt in range(3):
-        conn = HTTPSConnection("discord.com", timeout=_TIMEOUT)
-        try:
-            conn.request(method, path, body, headers)
-            resp = conn.getresponse()
-            status = resp.status
-            data = resp.read()
-        finally:
-            conn.close()
+        status, data = _send(method, path, body, headers)
 
         if status == 429 and attempt < 2:
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 
 class FakeDiscordResponse:
     """Minimal stub for urllib.request.urlopen responses."""
@@ -16,3 +18,36 @@ class FakeDiscordResponse:
 
     def __exit__(self, *_):
         return False
+
+
+class FakeAppHTTPSConnection:
+    """Stub for cordless.app.HTTPSConnection. One instance per fresh connection,
+    but requests/responses are tracked on the class so tests can see every
+    call even across a reconnect."""
+
+    requests = []
+    responses = []  # list of (status, headers, body) consumed per request
+
+    def __init__(self, host):
+        self.host = host
+
+    def request(self, method, path, body, headers):
+        FakeAppHTTPSConnection.requests.append({"method": method, "path": path, "body": body, "headers": headers})
+
+    def getresponse(self):
+        status, headers, body = FakeAppHTTPSConnection.responses.pop(0)
+        return type("R", (), {"status": status, "headers": headers, "read": lambda self: body})()
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def fake_app_conn(monkeypatch):
+    import cordless.app
+
+    FakeAppHTTPSConnection.requests = []
+    FakeAppHTTPSConnection.responses = []
+    monkeypatch.setattr(cordless.app, "HTTPSConnection", FakeAppHTTPSConnection)
+    monkeypatch.setattr(cordless.app, "_conn", None)
+    return FakeAppHTTPSConnection

--- a/tests/test_app_features.py
+++ b/tests/test_app_features.py
@@ -527,203 +527,138 @@ def test_edit_message_passes_files_through_to_discord_request():
     assert captured["files"] == files
 
 
-def test_discord_request_attaches_files_metadata_and_builds_multipart():
-    bot = Cordless()
-    captured = {}
+class FakeHTTPSConnection:
+    """Stub for cordless.app.HTTPSConnection. One instance per fresh connection,
+    but requests/responses are tracked on the class so tests can see every
+    call even across a reconnect."""
 
-    def fake_urlopen(req):
-        captured["headers"] = dict(req.header_items())
-        captured["body"] = req.data
+    requests = []
+    responses = []  # list of (status, headers, body) consumed per request
 
-        class _Resp:
-            def __enter__(self_):
-                return self_
+    def __init__(self, host):
+        self.host = host
 
-            def __exit__(self_, *a):
-                return False
+    def request(self, method, path, body, headers):
+        FakeHTTPSConnection.requests.append({"method": method, "path": path, "body": body, "headers": headers})
 
-            def read(self_):
-                return b"{}"
+    def getresponse(self):
+        status, headers, body = FakeHTTPSConnection.responses.pop(0)
+        return type("R", (), {"status": status, "headers": headers, "read": lambda self: body})()
 
-            headers = {}
+    def close(self):
+        pass
 
-        return _Resp()
 
+@pytest.fixture
+def fake_conn(monkeypatch):
+    import cordless.app
+
+    FakeHTTPSConnection.requests = []
+    FakeHTTPSConnection.responses = []
+    monkeypatch.setattr(cordless.app, "HTTPSConnection", FakeHTTPSConnection)
+    monkeypatch.setattr(cordless.app, "_conn", None)
+    return FakeHTTPSConnection
+
+
+def test_discord_request_attaches_files_metadata_and_builds_multipart(fake_conn):
     import os
 
-    with (
-        patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}),
-        patch("urllib.request.urlopen", side_effect=fake_urlopen),
-    ):
+    fake_conn.responses = [(200, {}, b"{}")]
+
+    with patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}):
+        bot = Cordless()
         bot._discord_request("POST", "/channels/123/messages", {"content": "hi"}, [("board.png", b"\x89PNG...")])
 
-    assert captured["headers"]["Content-type"].startswith("multipart/form-data; boundary=")
-    assert b'name="files[0]"; filename="board.png"' in captured["body"]
-    assert b'name="payload_json"' in captured["body"]
-    assert b'"attachments": [{"id": 0, "filename": "board.png"}]' in captured["body"]
+    sent = fake_conn.requests[0]
+    assert sent["headers"]["Content-Type"].startswith("multipart/form-data; boundary=")
+    assert b'name="files[0]"; filename="board.png"' in sent["body"]
+    assert b'name="payload_json"' in sent["body"]
+    assert b'"attachments": [{"id": 0, "filename": "board.png"}]' in sent["body"]
 
 
-def test_discord_request_checks_ratelimit_before_sending(monkeypatch):
-    import cordless.ratelimit as ratelimit
-
-    bot = Cordless()
-    calls = []
-    monkeypatch.setattr(ratelimit, "wait_if_needed", lambda method, path: calls.append((method, path)))
-
-    class _Resp:
-        headers = {}
-
-        def __enter__(self_):
-            return self_
-
-        def __exit__(self_, *a):
-            return False
-
-        def read(self_):
-            return b"{}"
-
+def test_discord_request_checks_ratelimit_before_sending(fake_conn, monkeypatch):
     import os
 
-    with (
-        patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}),
-        patch("urllib.request.urlopen", return_value=_Resp()),
-    ):
+    import cordless.ratelimit as ratelimit
+
+    calls = []
+    monkeypatch.setattr(ratelimit, "wait_if_needed", lambda method, path: calls.append((method, path)))
+    fake_conn.responses = [(200, {}, b"{}")]
+
+    with patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}):
+        bot = Cordless()
         bot._discord_request("POST", "/channels/123/messages", {"content": "hi"})
 
     assert calls == [("POST", "/channels/123/messages")]
 
 
-def test_discord_request_records_response_headers_on_success(monkeypatch):
+def test_discord_request_records_response_headers_on_success(fake_conn, monkeypatch):
+    import os
+
     import cordless.ratelimit as ratelimit
 
-    bot = Cordless()
     recorded = []
     monkeypatch.setattr(ratelimit, "record_response", lambda method, path, headers: recorded.append(headers))
+    resp_headers = {"X-RateLimit-Remaining": "4", "X-RateLimit-Reset-After": "1"}
+    fake_conn.responses = [(200, resp_headers, b"{}")]
 
-    class _Resp:
-        headers = {"X-RateLimit-Remaining": "4", "X-RateLimit-Reset-After": "1"}
-
-        def __enter__(self_):
-            return self_
-
-        def __exit__(self_, *a):
-            return False
-
-        def read(self_):
-            return b"{}"
-
-    import os
-
-    with (
-        patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}),
-        patch("urllib.request.urlopen", return_value=_Resp()),
-    ):
+    with patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}):
+        bot = Cordless()
         bot._discord_request("POST", "/channels/123/messages", {"content": "hi"})
 
-    assert recorded == [_Resp.headers]
+    assert recorded == [resp_headers]
 
 
-def test_discord_request_retries_once_on_429_then_succeeds(monkeypatch):
-    import io
+def test_discord_request_retries_once_on_429_then_succeeds(fake_conn, monkeypatch):
     import os
     import time
-    import urllib.error
 
     import cordless.ratelimit as ratelimit
 
-    bot = Cordless()
     blocked = []
     monkeypatch.setattr(ratelimit, "note_blocked", lambda method, path, retry_after: blocked.append(retry_after))
     monkeypatch.setattr(time, "sleep", lambda s: None)
+    fake_conn.responses = [
+        (429, {}, json.dumps({"retry_after": 0.2}).encode()),
+        (200, {}, b"{}"),
+    ]
 
-    class _Resp:
-        headers = {}
-
-        def __enter__(self_):
-            return self_
-
-        def __exit__(self_, *a):
-            return False
-
-        def read(self_):
-            return b"{}"
-
-    too_many_requests = urllib.error.HTTPError(
-        "url", 429, "rate limited", {}, io.BytesIO(json.dumps({"retry_after": 0.2}).encode())
-    )
-    responses = [too_many_requests, _Resp()]
-
-    def fake_urlopen(req):
-        resp = responses.pop(0)
-        if isinstance(resp, BaseException):
-            raise resp
-        return resp
-
-    with (
-        patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}),
-        patch("urllib.request.urlopen", side_effect=fake_urlopen),
-    ):
+    with patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}):
+        bot = Cordless()
         result = bot._discord_request("POST", "/channels/123/messages", {"content": "hi"})
 
     assert result == b"{}"
     assert blocked == [0.2]
 
 
-def test_discord_request_rechecks_ratelimit_on_each_retry_attempt(monkeypatch):
+def test_discord_request_rechecks_ratelimit_on_each_retry_attempt(fake_conn, monkeypatch):
     """wait_if_needed must run before every attempt, not just the first - otherwise a
     sibling call's note_blocked() from a moment ago is never consulted before retrying."""
-    import io
     import os
     import time
-    import urllib.error
 
     import cordless.ratelimit as ratelimit
 
-    bot = Cordless()
     waits = []
     monkeypatch.setattr(ratelimit, "wait_if_needed", lambda method, path: waits.append((method, path)))
     monkeypatch.setattr(ratelimit, "note_blocked", lambda method, path, retry_after: None)
     monkeypatch.setattr(time, "sleep", lambda s: None)
+    fake_conn.responses = [
+        (429, {}, json.dumps({"retry_after": 0.1}).encode()),
+        (200, {}, b"{}"),
+    ]
 
-    class _Resp:
-        headers = {}
-
-        def __enter__(self_):
-            return self_
-
-        def __exit__(self_, *a):
-            return False
-
-        def read(self_):
-            return b"{}"
-
-    too_many_requests = urllib.error.HTTPError(
-        "url", 429, "rate limited", {}, io.BytesIO(json.dumps({"retry_after": 0.1}).encode())
-    )
-    responses = [too_many_requests, _Resp()]
-
-    def fake_urlopen(req):
-        resp = responses.pop(0)
-        if isinstance(resp, BaseException):
-            raise resp
-        return resp
-
-    with (
-        patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}),
-        patch("urllib.request.urlopen", side_effect=fake_urlopen),
-    ):
+    with patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}):
+        bot = Cordless()
         bot._discord_request("POST", "/channels/123/messages", {"content": "hi"})
 
     assert waits == [("POST", "/channels/123/messages"), ("POST", "/channels/123/messages")]
 
 
-def test_discord_request_gives_up_after_retry_budget_exhausted(monkeypatch):
-    import io
+def test_discord_request_gives_up_after_retry_budget_exhausted(fake_conn, monkeypatch):
     import os
     import time
-    import urllib.error
 
-    bot = Cordless()
     monkeypatch.setattr(time, "sleep", lambda s: None)
     # jump straight past _MAX_RETRY_SECONDS on the very first check, so this test
     # doesn't actually spend 30 real seconds retrying against a mocked 429
@@ -734,17 +669,13 @@ def test_discord_request_gives_up_after_retry_budget_exhausted(monkeypatch):
         return clock[0]
 
     monkeypatch.setattr(time, "monotonic", fake_monotonic)
-
-    def fake_urlopen(req):
-        return (_ for _ in ()).throw(
-            urllib.error.HTTPError("url", 429, "rate limited", {}, io.BytesIO(b'{"retry_after": 0.1}'))
-        )
+    fake_conn.responses = [(429, {}, b'{"retry_after": 0.1}')] * 5
 
     with (
         patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}),
-        patch("urllib.request.urlopen", side_effect=fake_urlopen),
         pytest.raises(RuntimeError, match="429"),
     ):
+        bot = Cordless()
         bot._discord_request("POST", "/channels/123/messages", {"content": "hi"})
 
 

--- a/tests/test_app_features.py
+++ b/tests/test_app_features.py
@@ -527,63 +527,30 @@ def test_edit_message_passes_files_through_to_discord_request():
     assert captured["files"] == files
 
 
-class FakeHTTPSConnection:
-    """Stub for cordless.app.HTTPSConnection. One instance per fresh connection,
-    but requests/responses are tracked on the class so tests can see every
-    call even across a reconnect."""
-
-    requests = []
-    responses = []  # list of (status, headers, body) consumed per request
-
-    def __init__(self, host):
-        self.host = host
-
-    def request(self, method, path, body, headers):
-        FakeHTTPSConnection.requests.append({"method": method, "path": path, "body": body, "headers": headers})
-
-    def getresponse(self):
-        status, headers, body = FakeHTTPSConnection.responses.pop(0)
-        return type("R", (), {"status": status, "headers": headers, "read": lambda self: body})()
-
-    def close(self):
-        pass
-
-
-@pytest.fixture
-def fake_conn(monkeypatch):
-    import cordless.app
-
-    FakeHTTPSConnection.requests = []
-    FakeHTTPSConnection.responses = []
-    monkeypatch.setattr(cordless.app, "HTTPSConnection", FakeHTTPSConnection)
-    monkeypatch.setattr(cordless.app, "_conn", None)
-    return FakeHTTPSConnection
-
-
-def test_discord_request_attaches_files_metadata_and_builds_multipart(fake_conn):
+def test_discord_request_attaches_files_metadata_and_builds_multipart(fake_app_conn):
     import os
 
-    fake_conn.responses = [(200, {}, b"{}")]
+    fake_app_conn.responses = [(200, {}, b"{}")]
 
     with patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}):
         bot = Cordless()
         bot._discord_request("POST", "/channels/123/messages", {"content": "hi"}, [("board.png", b"\x89PNG...")])
 
-    sent = fake_conn.requests[0]
+    sent = fake_app_conn.requests[0]
     assert sent["headers"]["Content-Type"].startswith("multipart/form-data; boundary=")
     assert b'name="files[0]"; filename="board.png"' in sent["body"]
     assert b'name="payload_json"' in sent["body"]
     assert b'"attachments": [{"id": 0, "filename": "board.png"}]' in sent["body"]
 
 
-def test_discord_request_checks_ratelimit_before_sending(fake_conn, monkeypatch):
+def test_discord_request_checks_ratelimit_before_sending(fake_app_conn, monkeypatch):
     import os
 
     import cordless.ratelimit as ratelimit
 
     calls = []
     monkeypatch.setattr(ratelimit, "wait_if_needed", lambda method, path: calls.append((method, path)))
-    fake_conn.responses = [(200, {}, b"{}")]
+    fake_app_conn.responses = [(200, {}, b"{}")]
 
     with patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}):
         bot = Cordless()
@@ -592,7 +559,7 @@ def test_discord_request_checks_ratelimit_before_sending(fake_conn, monkeypatch)
     assert calls == [("POST", "/channels/123/messages")]
 
 
-def test_discord_request_records_response_headers_on_success(fake_conn, monkeypatch):
+def test_discord_request_records_response_headers_on_success(fake_app_conn, monkeypatch):
     import os
 
     import cordless.ratelimit as ratelimit
@@ -600,7 +567,7 @@ def test_discord_request_records_response_headers_on_success(fake_conn, monkeypa
     recorded = []
     monkeypatch.setattr(ratelimit, "record_response", lambda method, path, headers: recorded.append(headers))
     resp_headers = {"X-RateLimit-Remaining": "4", "X-RateLimit-Reset-After": "1"}
-    fake_conn.responses = [(200, resp_headers, b"{}")]
+    fake_app_conn.responses = [(200, resp_headers, b"{}")]
 
     with patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}):
         bot = Cordless()
@@ -609,7 +576,7 @@ def test_discord_request_records_response_headers_on_success(fake_conn, monkeypa
     assert recorded == [resp_headers]
 
 
-def test_discord_request_retries_once_on_429_then_succeeds(fake_conn, monkeypatch):
+def test_discord_request_retries_once_on_429_then_succeeds(fake_app_conn, monkeypatch):
     import os
     import time
 
@@ -618,7 +585,7 @@ def test_discord_request_retries_once_on_429_then_succeeds(fake_conn, monkeypatc
     blocked = []
     monkeypatch.setattr(ratelimit, "note_blocked", lambda method, path, retry_after: blocked.append(retry_after))
     monkeypatch.setattr(time, "sleep", lambda s: None)
-    fake_conn.responses = [
+    fake_app_conn.responses = [
         (429, {}, json.dumps({"retry_after": 0.2}).encode()),
         (200, {}, b"{}"),
     ]
@@ -631,7 +598,7 @@ def test_discord_request_retries_once_on_429_then_succeeds(fake_conn, monkeypatc
     assert blocked == [0.2]
 
 
-def test_discord_request_rechecks_ratelimit_on_each_retry_attempt(fake_conn, monkeypatch):
+def test_discord_request_rechecks_ratelimit_on_each_retry_attempt(fake_app_conn, monkeypatch):
     """wait_if_needed must run before every attempt, not just the first - otherwise a
     sibling call's note_blocked() from a moment ago is never consulted before retrying."""
     import os
@@ -643,7 +610,7 @@ def test_discord_request_rechecks_ratelimit_on_each_retry_attempt(fake_conn, mon
     monkeypatch.setattr(ratelimit, "wait_if_needed", lambda method, path: waits.append((method, path)))
     monkeypatch.setattr(ratelimit, "note_blocked", lambda method, path, retry_after: None)
     monkeypatch.setattr(time, "sleep", lambda s: None)
-    fake_conn.responses = [
+    fake_app_conn.responses = [
         (429, {}, json.dumps({"retry_after": 0.1}).encode()),
         (200, {}, b"{}"),
     ]
@@ -655,7 +622,7 @@ def test_discord_request_rechecks_ratelimit_on_each_retry_attempt(fake_conn, mon
     assert waits == [("POST", "/channels/123/messages"), ("POST", "/channels/123/messages")]
 
 
-def test_discord_request_gives_up_after_retry_budget_exhausted(fake_conn, monkeypatch):
+def test_discord_request_gives_up_after_retry_budget_exhausted(fake_app_conn, monkeypatch):
     import os
     import time
 
@@ -669,7 +636,7 @@ def test_discord_request_gives_up_after_retry_budget_exhausted(fake_conn, monkey
         return clock[0]
 
     monkeypatch.setattr(time, "monotonic", fake_monotonic)
-    fake_conn.responses = [(429, {}, b'{"retry_after": 0.1}')] * 5
+    fake_app_conn.responses = [(429, {}, b'{"retry_after": 0.1}')] * 5
 
     with (
         patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "tok"}),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -185,7 +185,7 @@ def test_pick_returns_none_when_all_none():
 
 def test_init_creates_scaffold(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    main(["init", "mybot"])
+    main(["init", "mybot", "--endpoint", "function_url"])
     assert (tmp_path / "lambda_function.py").exists()
     assert (tmp_path / "cordless.toml").exists()
     assert (tmp_path / ".env.example").exists()
@@ -197,9 +197,47 @@ def test_init_creates_scaffold(tmp_path, monkeypatch):
 def test_init_skips_existing_files(tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "lambda_function.py").write_text("existing")
-    main(["init"])
+    main(["init", "--endpoint", "function_url"])
     assert (tmp_path / "lambda_function.py").read_text() == "existing"
     assert "already exists" in capsys.readouterr().out
+
+
+def test_init_endpoint_flag_writes_toml_value(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    main(["init", "--endpoint", "api_gateway"])
+    assert 'endpoint = "api_gateway"' in (tmp_path / "cordless.toml").read_text()
+
+
+def test_init_without_endpoint_flag_prompts_when_interactive(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    with patch("builtins.input", return_value="2"):
+        main(["init"])
+    assert 'endpoint = "api_gateway"' in (tmp_path / "cordless.toml").read_text()
+
+
+def test_init_prompt_accepts_endpoint_name_not_just_number(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    with patch("builtins.input", return_value="function_url"):
+        main(["init"])
+    assert 'endpoint = "function_url"' in (tmp_path / "cordless.toml").read_text()
+
+
+def test_init_prompt_rejects_invalid_input_and_asks_again(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    with patch("builtins.input", side_effect=["banana", "1"]):
+        main(["init"])
+    assert 'endpoint = "function_url"' in (tmp_path / "cordless.toml").read_text()
+
+
+def test_init_without_endpoint_flag_fails_fast_when_not_interactive(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    with pytest.raises(SystemExit, match="--endpoint"):
+        main(["init"])
+    assert not (tmp_path / "cordless.toml").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_defer.py
+++ b/tests/test_defer.py
@@ -130,6 +130,7 @@ def fake_conn(monkeypatch):
     FakeHTTPSConnection.requests = []
     FakeHTTPSConnection.responses = []
     monkeypatch.setattr(cordless.defer, "HTTPSConnection", FakeHTTPSConnection)
+    monkeypatch.setattr(cordless.defer, "_conn", None)
     return FakeHTTPSConnection
 
 

--- a/tests/test_defer.py
+++ b/tests/test_defer.py
@@ -268,6 +268,20 @@ def test_cron_runs_via_worker_handler():
     assert ran == ["tick"]
 
 
+def test_keepwarm_returns_without_dispatching_anything():
+    bot = Cordless()
+    ran = []
+
+    @bot.cron("rate(1 day)")
+    async def daily():
+        ran.append("daily")
+
+    handler = bot.handler()
+    result = handler({"_cordless_keepwarm": True})
+    assert result is None
+    assert ran == []
+
+
 def test_unknown_cron_raises():
     from cordless.errors import CordlessError
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -249,6 +249,35 @@ def test_ensure_function_url_grants_both_required_permission_statements(aws_clie
     assert invoke_function_stmt.get("InvokedViaFunctionUrl") is True
 
 
+def test_ensure_function_url_heals_missing_permission_on_existing_url(aws_clients, tmp_path):
+    """A function whose URL config was created by an older cordless version (or
+    a partially failed earlier deploy) may already have the URL but be missing
+    the lambda:InvokeFunction statement. Calling _ensure_function_url again -
+    e.g. on a routine redeploy - must add the missing statement, not skip
+    straight past it because the URL config already exists."""
+    iam, lam = aws_clients["iam"], aws_clients["lam"]
+    role_arn = _make_role(iam)
+    _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+
+    # simulate the old, incomplete setup: URL config + only the first statement
+    lam.create_function_url_config(FunctionName="my-fn", AuthType="NONE")
+    lam.add_permission(
+        FunctionName="my-fn",
+        StatementId="FunctionURLAllowPublicAccess",
+        Action="lambda:InvokeFunctionUrl",
+        Principal="*",
+        FunctionUrlAuthType="NONE",
+    )
+    policy = json.loads(lam.get_policy(FunctionName="my-fn")["Policy"])
+    assert {s["Action"] for s in policy["Statement"]} == {"lambda:InvokeFunctionUrl"}
+
+    _ensure_function_url(lam, "my-fn")
+
+    policy = json.loads(lam.get_policy(FunctionName="my-fn")["Policy"])
+    actions = {stmt["Action"] for stmt in policy["Statement"]}
+    assert actions == {"lambda:InvokeFunctionUrl", "lambda:InvokeFunction"}
+
+
 # ---------------------------------------------------------------------------
 # _list_all_apis / _list_all_layer_versions (pagination)
 # ---------------------------------------------------------------------------

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -363,6 +363,40 @@ def test_deploy_warns_when_pynacl_bundle_failed(deploy_patches, monkeypatch, cap
 
 
 @mock_aws
+def test_deploy_defaults_new_function_to_arm64(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches))
+    lam = boto3.client("lambda", region_name=REGION)
+    config = lam.get_function_configuration(FunctionName="my-bot")
+    assert config["Architectures"] == ["arm64"]
+
+
+@mock_aws
+def test_deploy_keeps_existing_architecture_when_unspecified(deploy_patches, monkeypatch):
+    """AWS won't let an existing function's architecture change in place, so a
+    redeploy that doesn't ask for a specific architecture must not try to flip it."""
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    kwargs = _base_deploy_kwargs(deploy_patches)
+    deploy(**kwargs, architecture="x86_64")
+    deploy(**kwargs)  # no architecture given this time
+    lam = boto3.client("lambda", region_name=REGION)
+    config = lam.get_function_configuration(FunctionName="my-bot")
+    assert config["Architectures"] == ["x86_64"]
+
+
+@mock_aws
+def test_deploy_explicit_architecture_always_wins(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches, architecture="x86_64"))
+    lam = boto3.client("lambda", region_name=REGION)
+    config = lam.get_function_configuration(FunctionName="my-bot")
+    assert config["Architectures"] == ["x86_64"]
+
+
+@mock_aws
 def test_deploy_creates_worker_when_configured(deploy_patches, monkeypatch):
     iam = boto3.client("iam", region_name=REGION)
     monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -13,7 +13,9 @@ from cordless.deploy import (
     _ensure_function_url,
     _function_exists,
     _publish_cordless_layer,
+    _remove_keepwarm,
     _wire_crons,
+    _wire_keepwarm,
     deploy,
     destroy,
     ensure_iam_role,
@@ -389,6 +391,63 @@ def test_wire_crons_is_idempotent(aws_clients, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# _wire_keepwarm / _remove_keepwarm
+# ---------------------------------------------------------------------------
+
+
+def test_wire_keepwarm_creates_rule_targeting_main(aws_clients, tmp_path):
+    """The whole point: this must always target the main function directly,
+    never a defer_worker - regular crons can't do that, since they all share
+    one target."""
+    iam, lam, events = aws_clients["iam"], aws_clients["lam"], aws_clients["events"]
+    role_arn = _make_role(iam)
+    fn_arn = _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+    _wire_keepwarm(events, lam, "my-fn", fn_arn, True)
+
+    rules = events.list_rules(NamePrefix="my-fn-keepwarm")["Rules"]
+    assert len(rules) == 1
+    assert rules[0]["ScheduleExpression"] == "rate(5 minutes)"
+    targets = events.list_targets_by_rule(Rule="my-fn-keepwarm")["Targets"]
+    assert targets[0]["Arn"] == fn_arn
+    assert json.loads(targets[0]["Input"]) == {"_cordless_keepwarm": True}
+
+
+def test_wire_keepwarm_accepts_custom_schedule(aws_clients, tmp_path):
+    iam, lam, events = aws_clients["iam"], aws_clients["lam"], aws_clients["events"]
+    role_arn = _make_role(iam)
+    fn_arn = _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+    _wire_keepwarm(events, lam, "my-fn", fn_arn, "rate(10 minutes)")
+
+    rules = events.list_rules(NamePrefix="my-fn-keepwarm")["Rules"]
+    assert rules[0]["ScheduleExpression"] == "rate(10 minutes)"
+
+
+def test_wire_keepwarm_is_idempotent(aws_clients, tmp_path):
+    iam, lam, events = aws_clients["iam"], aws_clients["lam"], aws_clients["events"]
+    role_arn = _make_role(iam)
+    fn_arn = _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+    _wire_keepwarm(events, lam, "my-fn", fn_arn, True)
+    _wire_keepwarm(events, lam, "my-fn", fn_arn, True)
+    assert len(events.list_rules(NamePrefix="my-fn-keepwarm")["Rules"]) == 1
+
+
+def test_wire_keepwarm_false_removes_existing_rule(aws_clients, tmp_path):
+    iam, lam, events = aws_clients["iam"], aws_clients["lam"], aws_clients["events"]
+    role_arn = _make_role(iam)
+    fn_arn = _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+    _wire_keepwarm(events, lam, "my-fn", fn_arn, True)
+    _wire_keepwarm(events, lam, "my-fn", fn_arn, None)
+    assert events.list_rules(NamePrefix="my-fn-keepwarm")["Rules"] == []
+
+
+def test_remove_keepwarm_is_safe_when_nothing_exists(aws_clients, tmp_path):
+    iam, lam, events = aws_clients["iam"], aws_clients["lam"], aws_clients["events"]
+    role_arn = _make_role(iam)
+    _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+    _remove_keepwarm(events, lam, "my-fn")  # must not raise
+
+
+# ---------------------------------------------------------------------------
 # deploy / destroy integration
 # ---------------------------------------------------------------------------
 
@@ -555,6 +614,53 @@ def test_deploy_wires_crons(deploy_patches, monkeypatch):
     events = boto3.client("events", region_name=REGION)
     rules = events.list_rules(NamePrefix="my-bot-cron-")["Rules"]
     assert any(r["Name"] == "my-bot-cron-daily" for r in rules)
+
+
+@mock_aws
+def test_deploy_keepwarm_targets_main_even_with_defer_worker(deploy_patches, monkeypatch):
+    """The whole reason this feature exists: regular crons all go to
+    defer_worker when it's set, leaving the main function - the one every
+    Discord interaction hits first - with nothing keeping it warm."""
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(
+        **_base_deploy_kwargs(
+            deploy_patches,
+            defer_worker="my-bot-worker",
+            crons={"daily": "rate(1 day)"},
+            keep_warm=True,
+        )
+    )
+    lam = boto3.client("lambda", region_name=REGION)
+    events = boto3.client("events", region_name=REGION)
+
+    main_arn = lam.get_function_configuration(FunctionName="my-bot")["FunctionArn"]
+    targets = events.list_targets_by_rule(Rule="my-bot-keepwarm")["Targets"]
+    assert targets[0]["Arn"] == main_arn
+
+    # the regular cron, meanwhile, still goes to the worker as usual
+    worker_arn = lam.get_function_configuration(FunctionName="my-bot-worker")["FunctionArn"]
+    cron_targets = events.list_targets_by_rule(Rule="my-bot-cron-daily")["Targets"]
+    assert cron_targets[0]["Arn"] == worker_arn
+
+
+@mock_aws
+def test_deploy_without_keepwarm_does_not_create_a_rule(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches))
+    events = boto3.client("events", region_name=REGION)
+    assert events.list_rules(NamePrefix="my-bot-keepwarm")["Rules"] == []
+
+
+@mock_aws
+def test_destroy_removes_keepwarm_rule(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches, keep_warm=True))
+    destroy(function_name="my-bot", role_name="my-bot-role", region=REGION)
+    events = boto3.client("events", region_name=REGION)
+    assert events.list_rules(NamePrefix="my-bot-keepwarm")["Rules"] == []
 
 
 @mock_aws

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -343,6 +343,26 @@ def test_deploy_is_idempotent(deploy_patches, monkeypatch):
 
 
 @mock_aws
+def test_deploy_warns_when_pynacl_bundle_failed(deploy_patches, monkeypatch, capsys):
+    import cordless.upload
+
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    cordless.upload.pynacl_bundle_failed = False
+
+    def _fresh_zip_with_pynacl_failure(*a, **kw):
+        cordless.upload.pynacl_bundle_failed = True
+        return _minimal_zip(deploy_patches)
+
+    monkeypatch.setattr(cordless.deploy, "build_function_zip", _fresh_zip_with_pynacl_failure)
+
+    url = deploy(**_base_deploy_kwargs(deploy_patches))
+
+    assert url  # deploy must still succeed, not raise
+    assert "could not bundle pynacl" in capsys.readouterr().out
+
+
+@mock_aws
 def test_deploy_creates_worker_when_configured(deploy_patches, monkeypatch):
     iam = boto3.client("iam", region_name=REGION)
     monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -10,6 +10,7 @@ import cordless.deploy
 from cordless.deploy import (
     _allow_worker_invoke,
     _ensure_api_gateway,
+    _ensure_function_url,
     _function_exists,
     _publish_cordless_layer,
     _wire_crons,
@@ -206,6 +207,48 @@ def test_ensure_api_gateway_is_idempotent(aws_clients, tmp_path):
     assert len(apigw.get_apis()["Items"]) == 1
 
 
+def test_ensure_function_url_creates_url(aws_clients, tmp_path):
+    iam, lam = aws_clients["iam"], aws_clients["lam"]
+    role_arn = _make_role(iam)
+    _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+    url = _ensure_function_url(lam, "my-fn")
+    assert url
+    assert lam.get_function_url_config(FunctionName="my-fn")["FunctionUrl"] == url
+
+
+def test_ensure_function_url_is_idempotent(aws_clients, tmp_path):
+    iam, lam = aws_clients["iam"], aws_clients["lam"]
+    role_arn = _make_role(iam)
+    _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+    url1 = _ensure_function_url(lam, "my-fn")
+    url2 = _ensure_function_url(lam, "my-fn")
+    assert url1 == url2
+
+
+def test_ensure_function_url_grants_both_required_permission_statements(aws_clients, tmp_path):
+    """AWS requires two resource-policy statements for a public (AuthType=NONE)
+    function URL, not one - lambda:InvokeFunctionUrl, and (since October 2025)
+    a second lambda:InvokeFunction statement gated on InvokedViaFunctionUrl.
+    Without the second one every request 403s before it reaches the handler,
+    which is what silently broke Discord's endpoint verification."""
+    iam, lam = aws_clients["iam"], aws_clients["lam"]
+    role_arn = _make_role(iam)
+    _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+    _ensure_function_url(lam, "my-fn")
+
+    policy = json.loads(lam.get_policy(FunctionName="my-fn")["Policy"])
+    actions = {stmt["Action"] for stmt in policy["Statement"]}
+    assert "lambda:InvokeFunctionUrl" in actions
+    assert "lambda:InvokeFunction" in actions
+
+    # moto represents InvokedViaFunctionUrl as a flat statement key rather than
+    # the real Condition:{Bool:{lambda:InvokedViaFunctionUrl}} shape AWS uses,
+    # so this checks moto's shape - the real shape was verified by hand against
+    # live AWS, which is what actually confirmed the fix
+    invoke_function_stmt = next(s for s in policy["Statement"] if s["Action"] == "lambda:InvokeFunction")
+    assert invoke_function_stmt.get("InvokedViaFunctionUrl") is True
+
+
 # ---------------------------------------------------------------------------
 # _list_all_apis / _list_all_layer_versions (pagination)
 # ---------------------------------------------------------------------------
@@ -394,6 +437,55 @@ def test_deploy_explicit_architecture_always_wins(deploy_patches, monkeypatch):
     lam = boto3.client("lambda", region_name=REGION)
     config = lam.get_function_configuration(FunctionName="my-bot")
     assert config["Architectures"] == ["x86_64"]
+
+
+@mock_aws
+def test_deploy_defaults_new_function_to_function_url(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches))
+    lam = boto3.client("lambda", region_name=REGION)
+    config = lam.get_function_url_config(FunctionName="my-bot")
+    assert config["FunctionUrl"]
+
+
+@mock_aws
+def test_deploy_keeps_existing_api_gateway_when_unspecified(deploy_patches, monkeypatch):
+    """A redeploy that doesn't ask for a specific endpoint must not silently
+    switch an existing API Gateway deployment over to a Function URL."""
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    kwargs = _base_deploy_kwargs(deploy_patches)
+    deploy(**kwargs, endpoint="api_gateway")
+    deploy(**kwargs)  # no endpoint given this time
+    lam = boto3.client("lambda", region_name=REGION)
+    with pytest.raises(lam.exceptions.ResourceNotFoundException):
+        lam.get_function_url_config(FunctionName="my-bot")
+    apigw = boto3.client("apigatewayv2", region_name=REGION)
+    apis = apigw.get_apis()["Items"]
+    assert any(a["Name"] == "my-bot-api" for a in apis)
+
+
+@mock_aws
+def test_deploy_keeps_existing_function_url_when_unspecified(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    kwargs = _base_deploy_kwargs(deploy_patches)
+    deploy(**kwargs, endpoint="function_url")
+    deploy(**kwargs)  # no endpoint given this time
+    lam = boto3.client("lambda", region_name=REGION)
+    config = lam.get_function_url_config(FunctionName="my-bot")
+    assert config["FunctionUrl"]
+
+
+@mock_aws
+def test_deploy_explicit_endpoint_always_wins(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches, endpoint="api_gateway"))
+    lam = boto3.client("lambda", region_name=REGION)
+    with pytest.raises(lam.exceptions.ResourceNotFoundException):
+        lam.get_function_url_config(FunctionName="my-bot")
 
 
 @mock_aws

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -3,7 +3,17 @@
 import os
 import zipfile
 
+import pytest
+
+import cordless.upload
 from cordless.deploy import _packages_cache_dir, build_function_zip, load_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_pynacl_bundle_failed():
+    cordless.upload.pynacl_bundle_failed = False
+    yield
+    cordless.upload.pynacl_bundle_failed = False
 
 
 def _zip_names(zip_path):
@@ -233,6 +243,7 @@ def test_layer_extras_dir_returns_none_when_fetch_fails(monkeypatch):
     monkeypatch.setattr(cordless.deploy, "_ensure_packages", boom)
 
     assert cordless.upload._layer_extras_dir("3.12") is None
+    assert cordless.upload.pynacl_bundle_failed is True
 
 
 def test_layer_zip_without_runtime_skips_extras(monkeypatch):

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -98,6 +98,7 @@ def test_bundle_cordless_includes_dist_info(tmp_path, monkeypatch):
     import cordless.upload
 
     monkeypatch.setattr(cordless.upload, "_cordless_package_dir", lambda: str(pkg_dir))
+    monkeypatch.setattr(cordless.upload, "_layer_extras_dir", lambda v, arch="x86_64": None)
 
     src = tmp_path / "src"
     src.mkdir()
@@ -108,6 +109,53 @@ def test_bundle_cordless_includes_dist_info(tmp_path, monkeypatch):
         names = _zip_names(zip_path)
         assert "cordless-1.0.0b2.dist-info/METADATA" in names
         assert "cordless-1.0.0b2.dist-info/RECORD" in names
+    finally:
+        os.unlink(zip_path)
+
+
+def test_bundle_cordless_includes_pynacl_extras(tmp_path, monkeypatch):
+    import cordless.deploy
+    import cordless.upload
+
+    pkg_dir = tmp_path / "site-packages" / "cordless"
+    _make_tree(pkg_dir, ["app.py", "__init__.py"])
+    monkeypatch.setattr(cordless.upload, "_cordless_package_dir", lambda: str(pkg_dir))
+
+    extras = tmp_path / "extras"
+    _make_tree(extras, ["nacl/signing.py", "nacl/_sodium.abi3.so"])
+    monkeypatch.setattr(cordless.upload, "_layer_extras_dir", lambda v, arch="x86_64": str(extras))
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "lambda_function.py").write_text("x")
+
+    zip_path = cordless.deploy.build_function_zip(str(src), bundle_cordless=True)
+    try:
+        names = _zip_names(zip_path)
+        assert "nacl/signing.py" in names
+        assert "nacl/_sodium.abi3.so" in names
+    finally:
+        os.unlink(zip_path)
+
+
+def test_bundle_cordless_survives_pynacl_fetch_failure(tmp_path, monkeypatch):
+    import cordless.deploy
+    import cordless.upload
+
+    pkg_dir = tmp_path / "site-packages" / "cordless"
+    _make_tree(pkg_dir, ["app.py", "__init__.py"])
+    monkeypatch.setattr(cordless.upload, "_cordless_package_dir", lambda: str(pkg_dir))
+    monkeypatch.setattr(cordless.upload, "_layer_extras_dir", lambda v, arch="x86_64": None)
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "lambda_function.py").write_text("x")
+
+    zip_path = cordless.deploy.build_function_zip(str(src), bundle_cordless=True)
+    try:
+        names = _zip_names(zip_path)
+        assert any(n.startswith("cordless/") for n in names)
+        assert not any("/nacl/" in n or n.startswith("nacl/") for n in names)
     finally:
         os.unlink(zip_path)
 
@@ -127,6 +175,7 @@ def test_bundle_cordless_includes_egg_info(tmp_path, monkeypatch):
     import cordless.upload
 
     monkeypatch.setattr(cordless.upload, "_cordless_package_dir", lambda: str(pkg_dir))
+    monkeypatch.setattr(cordless.upload, "_layer_extras_dir", lambda v, arch="x86_64": None)
 
     src = tmp_path / "src"
     src.mkdir()
@@ -172,6 +221,18 @@ def test_layer_zip_survives_pynacl_fetch_failure(monkeypatch):
         assert not any("/nacl/" in n for n in names)
     finally:
         os.unlink(zip_path)
+
+
+def test_layer_extras_dir_returns_none_when_fetch_fails(monkeypatch):
+    import cordless.deploy
+    import cordless.upload
+
+    def boom(pkgs, python_version, architecture):
+        raise RuntimeError("no matching wheel")
+
+    monkeypatch.setattr(cordless.deploy, "_ensure_packages", boom)
+
+    assert cordless.upload._layer_extras_dir("3.12") is None
 
 
 def test_layer_zip_without_runtime_skips_extras(monkeypatch):

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -148,6 +148,42 @@ def test_bundle_cordless_includes_pynacl_extras(tmp_path, monkeypatch):
         os.unlink(zip_path)
 
 
+def test_bundle_cordless_does_not_double_write_when_packages_overlaps_extras(tmp_path, monkeypatch):
+    """packages = ["pynacl"] plus bundle_cordless=True used to resolve to the same cache
+    dir as the extras fetch and write every file in it twice, which zipfile warns about
+    as a duplicate name."""
+    import warnings
+
+    import cordless.deploy
+    import cordless.upload
+
+    pkg_dir = tmp_path / "site-packages" / "cordless"
+    _make_tree(pkg_dir, ["app.py", "__init__.py"])
+    monkeypatch.setattr(cordless.upload, "_cordless_package_dir", lambda: str(pkg_dir))
+
+    # _layer_extras_dir and a user's own packages=["pynacl"] can resolve to the
+    # same cache dir in practice, so point both at one shared directory here
+    shared = tmp_path / "shared-pynacl-cache"
+    _make_tree(shared, ["nacl/signing.py", ".lock"])
+    monkeypatch.setattr(cordless.upload, "_layer_extras_dir", lambda v, arch="x86_64": str(shared))
+    monkeypatch.setattr(cordless.deploy, "_ensure_packages", lambda pkgs, v, arch: str(shared))
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "lambda_function.py").write_text("x")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        zip_path = cordless.deploy.build_function_zip(str(src), bundle_cordless=True, packages=["pynacl"])
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert names.count("nacl/signing.py") == 1
+        assert names.count(".lock") == 1
+    finally:
+        os.unlink(zip_path)
+
+
 def test_bundle_cordless_survives_pynacl_fetch_failure(tmp_path, monkeypatch):
     import cordless.deploy
     import cordless.upload
@@ -215,6 +251,35 @@ def test_layer_zip_bundles_pynacl_extras(tmp_path, monkeypatch):
         assert "python/nacl/signing.py" in names
         assert "python/nacl/_sodium.abi3.so" in names
         assert any(n.startswith("python/cordless/") for n in names)
+    finally:
+        os.unlink(zip_path)
+
+
+def test_layer_zip_does_not_double_write_overlapping_names(tmp_path, monkeypatch):
+    """cordless's own files and the pynacl extras can end up producing the same
+    relative zip path, which zipfile warns about as a duplicate name."""
+    import warnings
+
+    import cordless.upload
+
+    pkg_root = tmp_path / "site-packages"
+    pkg_dir = pkg_root / "cordless"
+    _make_tree(pkg_dir, ["app.py", "__init__.py"])
+    monkeypatch.setattr(cordless.upload, "_cordless_package_dir", lambda: str(pkg_dir))
+
+    extras = tmp_path / "extras"
+    # deliberately overlaps with a path the cordless walk also produces
+    _make_tree(extras, ["cordless/app.py", "nacl/signing.py"])
+    monkeypatch.setattr(cordless.upload, "_layer_extras_dir", lambda v, arch="x86_64": str(extras))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        zip_path = cordless.upload.build_layer_zip("3.12")
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+        assert names.count("python/cordless/app.py") == 1
+        assert "python/nacl/signing.py" in names
     finally:
         os.unlink(zip_path)
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -310,47 +310,44 @@ def test_execute_webhook_returns_none_without_wait(monkeypatch):
 # --- Cordless.create_webhook / get_channel_webhooks / delete_webhook (bot-token) ---
 
 
-def test_create_webhook_posts_to_channel_webhooks_endpoint(monkeypatch):
+def test_create_webhook_posts_to_channel_webhooks_endpoint(monkeypatch, fake_app_conn):
     import asyncio
 
     monkeypatch.setenv("DISCORD_BOT_TOKEN", "bot-tok")
-    responses = [FakeDiscordResponse({"id": "wh-1", "token": "wh-tok"})]
+    fake_app_conn.responses = [(200, {}, json.dumps({"id": "wh-1", "token": "wh-tok"}).encode())]
 
     bot = Cordless()
-    with patch("urllib.request.urlopen", side_effect=responses) as urlopen:
-        result = asyncio.run(bot.create_webhook("chan-1", "Alerts"))
+    result = asyncio.run(bot.create_webhook("chan-1", "Alerts"))
 
     assert result == {"id": "wh-1", "token": "wh-tok"}
-    req = urlopen.call_args_list[0].args[0]
-    assert req.full_url == "https://discord.com/api/v10/channels/chan-1/webhooks"
-    assert req.get_header("Authorization") == "Bot bot-tok"
-    assert json.loads(req.data) == {"name": "Alerts"}
+    sent = fake_app_conn.requests[0]
+    assert sent["path"] == "/api/v10/channels/chan-1/webhooks"
+    assert sent["headers"]["Authorization"] == "Bot bot-tok"
+    assert json.loads(sent["body"]) == {"name": "Alerts"}
 
 
-def test_get_channel_webhooks_lists_channel_webhooks(monkeypatch):
+def test_get_channel_webhooks_lists_channel_webhooks(monkeypatch, fake_app_conn):
     import asyncio
 
     monkeypatch.setenv("DISCORD_BOT_TOKEN", "bot-tok")
-    responses = [FakeDiscordResponse([{"id": "wh-1"}, {"id": "wh-2"}])]
+    fake_app_conn.responses = [(200, {}, json.dumps([{"id": "wh-1"}, {"id": "wh-2"}]).encode())]
 
     bot = Cordless()
-    with patch("urllib.request.urlopen", side_effect=responses) as urlopen:
-        result = asyncio.run(bot.get_channel_webhooks("chan-1"))
+    result = asyncio.run(bot.get_channel_webhooks("chan-1"))
 
     assert result == [{"id": "wh-1"}, {"id": "wh-2"}]
-    assert urlopen.call_args_list[0].args[0].full_url == "https://discord.com/api/v10/channels/chan-1/webhooks"
+    assert fake_app_conn.requests[0]["path"] == "/api/v10/channels/chan-1/webhooks"
 
 
-def test_delete_webhook_without_token_uses_bot_auth(monkeypatch):
+def test_delete_webhook_without_token_uses_bot_auth(monkeypatch, fake_app_conn):
     import asyncio
 
     monkeypatch.setenv("DISCORD_BOT_TOKEN", "bot-tok")
-    responses = [FakeDiscordResponse(None)]
+    fake_app_conn.responses = [(200, {}, b"")]
 
     bot = Cordless()
-    with patch("urllib.request.urlopen", side_effect=responses) as urlopen:
-        asyncio.run(bot.delete_webhook("wh-1"))
+    asyncio.run(bot.delete_webhook("wh-1"))
 
-    req = urlopen.call_args_list[0].args[0]
-    assert req.full_url == "https://discord.com/api/v10/webhooks/wh-1"
-    assert req.get_header("Authorization") == "Bot bot-tok"
+    sent = fake_app_conn.requests[0]
+    assert sent["path"] == "/api/v10/webhooks/wh-1"
+    assert sent["headers"]["Authorization"] == "Bot bot-tok"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -99,6 +99,7 @@ def fake_conn(monkeypatch):
     FakeHTTPSConnection.requests = []
     FakeHTTPSConnection.responses = []
     monkeypatch.setattr(cordless.webhook, "HTTPSConnection", FakeHTTPSConnection)
+    monkeypatch.setattr(cordless.webhook, "_conn", None)
     return FakeHTTPSConnection
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,10 +1,8 @@
 """Webhook support: URL parsing, payload building, and the execute/edit/delete/manage flows."""
 
 import json
-from unittest.mock import patch
 
 import pytest
-from conftest import FakeDiscordResponse
 
 import cordless.webhook
 from cordless.app import Cordless


### PR DESCRIPTION
## Summary

**Connection reuse (the core win).** `app.py`, `defer.py`, `webhook.py`, and `ratelimit.py` all used to open a fresh TCP+TLS connection (or boto3 DynamoDB resource) on every single Discord API call, even inside a warm Lambda container. All four now keep a persistent connection/handle at module scope, reused across invocations, with a one-shot reconnect if the far end closed it. Measured live against `discord.com`: ~100ms/request with a fresh connection vs ~36ms reused.

**Faster deploy defaults**
- PyNaCl (fast Ed25519 verify, ~6x faster than the pure-Python fallback) is now bundled for `bundle_cordless` deploys too, not just the default layer path. The fetch is non-fatal: a failure falls back to pure-Python verify with a clear post-deploy warning instead of aborting the whole deploy.
- `arm64` is now the default architecture for new functions; existing functions keep whatever they're already running, since AWS won't let that change in place.
- `cordless init` now defaults new projects to `us-east-1` (closest to Discord's own API infra: ~140-160ms from EU-hosted vs ~20-30ms from US-hosted, measured).

**Endpoint choice: Function URL vs API Gateway.** New `endpoint = "api_gateway" | "function_url"` option, defaulting new deployments to a direct Function URL (skips a network hop). An existing deployment keeps whichever it already has. Along the way, I found and fixed two bugs: AWS added a second required resource-policy statement for public Function URLs in October 2025 that nothing in the ecosystem accounted for yet, and a related bug where a function whose URL was created by an older version would never get the missing permission healed on redeploy. `cordless init` now asks which endpoint to use as a required interactive question (skippable via `--endpoint` for non-interactive use).

**Opt-in keep-warm cron.** `keep-warm = true` in `cordless.toml` pings the main function directly on a schedule so it doesn't go cold between real invocations. This needed its own mechanism because regular crons all share one target (the worker, if `defer_worker` is set); there was previously no way to keep the function that actually receives every Discord interaction warm at all.

**Misc fixes.** A zip-file duplicate-write bug in the packaging code (two source trees producing the same archive path), and general lint/test cleanup along the way.

## Test plan
- [x] Full suite passes
- [x] `uv run ruff check` clean
- [x] Function URL permission fix verified against real AWS (not just moto): reproduced the 403, confirmed the fix resolves it, confirmed the healing path fixes an already-broken deployment
- [x] Connection reuse benchmarked live against `discord.com`
- [x] PyNaCl vs pure-Python verify benchmarked live (2000 iterations each)