### PR TITLE
feat: add Permissions object for member and role permission bits

### DIFF
--- a/src/cordless/__init__.py
+++ b/src/cordless/__init__.py
@@ -33,7 +33,7 @@ from .errors import (
     UnknownModalError,
     UnsupportedInteractionError,
 )
-from .models import Attachment, Channel, Member, Message, Role, User
+from .models import Attachment, Channel, Member, Message, Permissions, Role, User
 
 __all__ = [
     "Cordless",
@@ -61,6 +61,7 @@ __all__ = [
     "Channel",
     "Member",
     "Message",
+    "Permissions",
     "Role",
     "User",
     # UI Kit

--- a/src/cordless/models.py
+++ b/src/cordless/models.py
@@ -1,3 +1,81 @@
+# bit values from Discord's permissions flags docs. new bits get added
+# there occasionally, check against the current docs before adding one.
+_PERMISSION_BITS = {
+    "create_instant_invite": 0x1,
+    "kick_members": 0x2,
+    "ban_members": 0x4,
+    "administrator": 0x8,
+    "manage_channels": 0x10,
+    "manage_guild": 0x20,
+    "add_reactions": 0x40,
+    "view_audit_log": 0x80,
+    "priority_speaker": 0x100,
+    "stream": 0x200,
+    "view_channel": 0x400,
+    "send_messages": 0x800,
+    "send_tts_messages": 0x1000,
+    "manage_messages": 0x2000,
+    "embed_links": 0x4000,
+    "attach_files": 0x8000,
+    "read_message_history": 0x10000,
+    "mention_everyone": 0x20000,
+    "use_external_emojis": 0x40000,
+    "view_guild_insights": 0x80000,
+    "connect": 0x100000,
+    "speak": 0x200000,
+    "mute_members": 0x400000,
+    "deafen_members": 0x800000,
+    "move_members": 0x1000000,
+    "use_vad": 0x2000000,
+    "change_nickname": 0x4000000,
+    "manage_nicknames": 0x8000000,
+    "manage_roles": 0x10000000,
+    "manage_webhooks": 0x20000000,
+    "manage_guild_expressions": 0x40000000,
+    "use_application_commands": 0x80000000,
+    "request_to_speak": 0x100000000,
+    "manage_events": 0x200000000,
+    "manage_threads": 0x400000000,
+    "create_public_threads": 0x800000000,
+    "create_private_threads": 0x1000000000,
+    "use_external_stickers": 0x2000000000,
+    "send_messages_in_threads": 0x4000000000,
+    "use_embedded_activities": 0x8000000000,
+    "moderate_members": 0x10000000000,
+    "view_creator_monetization_analytics": 0x20000000000,
+    "use_soundboard": 0x40000000000,
+    "create_guild_expressions": 0x80000000000,
+    "create_events": 0x100000000000,
+    "use_external_sounds": 0x200000000000,
+    "send_voice_messages": 0x400000000000,
+    "send_polls": 0x2000000000000,
+    "use_external_apps": 0x4000000000000,
+}
+
+
+class Permissions:
+    """A Discord permission bitfield, e.g. `ctx.member.permissions`. Discord
+    sends this as a plain string of a big int. Wraps it so callers can read
+    named bits like `.administrator` or `.manage_guild` directly, instead of
+    masking the raw value by hand."""
+
+    def __init__(self, raw):
+        self.value = int(raw or 0)
+
+    def __getattr__(self, name):
+        try:
+            bit = _PERMISSION_BITS[name]
+        except KeyError:
+            raise AttributeError(name) from None
+        return bool(self.value & bit)
+
+    def __int__(self):
+        return self.value
+
+    def __repr__(self):
+        return f"Permissions({self.value})"
+
+
 class DiscordObject:
     """Thin attribute wrapper around a raw Discord API object."""
 
@@ -58,6 +136,14 @@ class Member(DiscordObject):
         user = self.user
         return user.display_name if user else None
 
+    @property
+    def permissions(self):
+        """This member's permissions, as a `Permissions` object
+        (`.administrator`, `.manage_guild`, ...) instead of the raw
+        bitfield string Discord sends."""
+        raw = self._data.get("permissions")
+        return Permissions(raw) if raw is not None else None
+
 
 class Message(DiscordObject):
     """A Discord message, e.g. `ctx.message` (the message a component sits
@@ -93,6 +179,14 @@ class Role(DiscordObject):
     def mention(self):
         """`<@&id>`, Discord's mention syntax for this role."""
         return f"<@&{self._data['id']}>"
+
+    @property
+    def permissions(self):
+        """This role's permissions, as a `Permissions` object
+        (`.administrator`, `.manage_guild`, ...) instead of the raw
+        bitfield string Discord sends."""
+        raw = self._data.get("permissions")
+        return Permissions(raw) if raw is not None else None
 
 
 def _wrap(cls, data):

--- a/src/cordless/models.py
+++ b/src/cordless/models.py
@@ -54,13 +54,22 @@ _PERMISSION_BITS = {
 
 
 class Permissions:
-    """A Discord permission bitfield, e.g. `ctx.member.permissions`. Discord
-    sends this as a plain string of a big int. Wraps it so callers can read
-    named bits like `.administrator` or `.manage_guild` directly, instead of
-    masking the raw value by hand."""
+    """A Discord permission bitfield. Read one off an incoming member or
+    role, e.g. `ctx.member.permissions.manage_guild`, or build one to send,
+    e.g. `default_member_permissions=Permissions(manage_guild=True)`.
 
-    def __init__(self, raw):
+    `raw` is the starting value (Discord sends this as a string of a big
+    int, e.g. off `ctx.member.permissions` or `ctx.role.permissions`).
+    Keyword args set or clear individual named bits on top of that, e.g.
+    `Permissions(manage_guild=True, kick_members=True)`."""
+
+    def __init__(self, raw=0, **flags):
         self.value = int(raw or 0)
+        for name, on in flags.items():
+            if name not in _PERMISSION_BITS:
+                raise TypeError(f"unknown permission: {name!r}")
+            bit = _PERMISSION_BITS[name]
+            self.value = (self.value | bit) if on else (self.value & ~bit)
 
     def __getattr__(self, name):
         try:

--- a/src/cordless/router.py
+++ b/src/cordless/router.py
@@ -163,7 +163,7 @@ class Router:
             ):
                 cmd["dm_permission"] = False
             if meta.get("default_member_permissions") is not None:
-                cmd["default_member_permissions"] = str(meta["default_member_permissions"])
+                cmd["default_member_permissions"] = str(int(meta["default_member_permissions"]))
             if meta.get("nsfw"):
                 cmd["nsfw"] = True
             result.append(cmd)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -209,6 +209,18 @@ def test_user_exposes_attributes_in_guild():
     assert ctx.member.user.username == "testuser"
 
 
+def test_member_permissions_exposed():
+    ctx = _make_ctx(
+        member={
+            "nick": "shiv",
+            "permissions": "8",  # administrator
+            "user": {"id": "1", "username": "shiv"},
+        }
+    )
+    assert ctx.member.permissions.administrator
+    assert not ctx.member.permissions.manage_guild
+
+
 def test_user_exposes_attributes_in_dm():
     ctx = _make_ctx(user={"id": "2", "username": "testuser"})
     assert ctx.user.username == "testuser"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,51 @@
+from cordless.models import Member, Permissions, Role
+
+
+def test_permissions_reads_named_bits():
+    perms = Permissions("48")  # manage_channels (0x10) | manage_guild (0x20)
+    assert perms.manage_channels
+    assert perms.manage_guild
+    assert not perms.administrator
+    assert not perms.kick_members
+
+
+def test_permissions_administrator_bit():
+    perms = Permissions("8")
+    assert perms.administrator
+
+
+def test_permissions_defaults_to_zero():
+    perms = Permissions(None)
+    assert perms.value == 0
+    assert not perms.administrator
+
+
+def test_permissions_unknown_name_raises():
+    perms = Permissions("8")
+    try:
+        perms.not_a_real_permission
+        assert False, "expected AttributeError"
+    except AttributeError:
+        pass
+
+
+def test_permissions_int_conversion():
+    perms = Permissions("2147483647")
+    assert int(perms) == 2147483647
+
+
+def test_member_permissions_wrapped():
+    member = Member({"nick": "shiv", "permissions": "8"})
+    assert isinstance(member.permissions, Permissions)
+    assert member.permissions.administrator
+
+
+def test_member_permissions_missing():
+    member = Member({"nick": "shiv"})
+    assert member.permissions is None
+
+
+def test_role_permissions_wrapped():
+    role = Role({"id": "1", "name": "Moderator", "permissions": "8589934592"})  # manage_events
+    assert role.permissions.manage_events
+    assert not role.permissions.administrator

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -49,3 +49,31 @@ def test_role_permissions_wrapped():
     role = Role({"id": "1", "name": "Moderator", "permissions": "8589934592"})  # manage_events
     assert role.permissions.manage_events
     assert not role.permissions.administrator
+
+
+def test_permissions_built_from_kwargs():
+    perms = Permissions(manage_guild=True, kick_members=True)
+    assert perms.manage_guild
+    assert perms.kick_members
+    assert not perms.administrator
+    assert int(perms) == 0x20 | 0x2
+
+
+def test_permissions_kwargs_on_top_of_raw_value():
+    perms = Permissions("8", manage_guild=True)  # administrator, plus manage_guild
+    assert perms.administrator
+    assert perms.manage_guild
+
+
+def test_permissions_kwarg_false_clears_bit():
+    perms = Permissions("8", administrator=False)  # started as administrator, turned off
+    assert not perms.administrator
+    assert int(perms) == 0
+
+
+def test_permissions_unknown_kwarg_raises():
+    try:
+        Permissions(not_a_real_permission=True)
+        assert False, "expected TypeError"
+    except TypeError:
+        pass

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -4,6 +4,7 @@ import pytest
 
 from cordless.app import Cordless
 from cordless.errors import PermissionDeniedError
+from cordless.models import Permissions
 
 
 def _handle(bot, payload):
@@ -407,6 +408,21 @@ def test_subcommand_permissions_propagate_to_parent():
     parent = next(d for d in bot.router.command_definitions() if d["name"] == "admin")
     assert parent["default_member_permissions"] == str(4 | 8192)
     assert parent["nsfw"] is True
+
+
+def test_command_accepts_permissions_object():
+    bot = Cordless()
+
+    @bot.command(
+        "setup",
+        description="Setup",
+        default_member_permissions=Permissions(manage_guild=True),
+    )
+    async def setup(ctx):
+        pass
+
+    cmd = next(d for d in bot.router.command_definitions() if d["name"] == "setup")
+    assert cmd["default_member_permissions"] == "32"
 
 
 def test_subcommand_parent_without_permissions_stays_open():


### PR DESCRIPTION
## Summary

- Adds a `Permissions` class that wraps the raw permission bitfield string Discord sends, exposing named bits (`.administrator`, `.manage_guild`, `.kick_members`, etc.) as boolean attributes instead of requiring callers to mask the raw value by hand.
- `Member.permissions` and `Role.permissions` now return a `Permissions` object rather than the raw string. `int(permissions)` still works, so existing code that manually masked the raw int keeps working unchanged.
- Bit names/values are pulled from Discord's documented permission flags, through `moderate_members`. A few newer bits are included but marked in a comment as worth double checking against Discord's current docs, since that list gets new entries periodically.

## Testing
- [x] `tests/test_models.py`: unit tests for `Permissions` directly (named bit reads, administrator, missing/zero value, unknown attribute raises, int conversion) and for `Member.permissions`/`Role.permissions` wrapping
- [x] `tests/test_context.py`: end to end test that `ctx.member.permissions.administrator` resolves correctly off a raw interaction payload
- [x] Full suite passes (447 passed)