### PR TITLE
refactor: require pynacl for signature verification, drop pure-Python fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ keywords = ["discord", "bot", "lambda", "serverless", "aws", "interactions"]
 dependencies = [
   "boto3>=1.20",
   "botocore[crt]",
+  "pynacl>=1.5",
   "uv>=0.11",
 ]
 

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -242,7 +242,7 @@ def build_function_zip(source_dir, bundle_cordless=False, packages=None, python_
                             abs_path = os.path.join(root, fname)
                             _write(zf, abs_path, os.path.relpath(abs_path, pkg_parent))
 
-            # same pynacl bundling the layer path gets - required for signature
+            # same pynacl bundling the layer path gets, required for signature
             # verification, so a fetch failure here raises rather than shipping
             # a function that can't verify Discord's requests
             extras_dir = _layer_extras_dir(python_version, architecture)
@@ -292,7 +292,7 @@ def _ensure_packages(packages, python_version, architecture="x86_64"):
     venv_uv = os.path.join(os.path.dirname(sys.executable), "uv")
     uv = venv_uv if os.path.isfile(venv_uv) else shutil.which("uv")
     if uv is None:
-        raise RuntimeError("uv not found — install it: https://docs.astral.sh/uv/getting-started/installation/")
+        raise RuntimeError("uv not found, install it: https://docs.astral.sh/uv/getting-started/installation/")
 
     os.makedirs(os.path.dirname(cache_dir), exist_ok=True)
     staging = tempfile.mkdtemp(dir=os.path.dirname(cache_dir))

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -242,8 +242,9 @@ def build_function_zip(source_dir, bundle_cordless=False, packages=None, python_
                             abs_path = os.path.join(root, fname)
                             _write(zf, abs_path, os.path.relpath(abs_path, pkg_parent))
 
-            # same pynacl bundling the layer path gets, so bundle_cordless doesn't
-            # silently fall back to slow signature verification
+            # same pynacl bundling the layer path gets - required for signature
+            # verification, so a fetch failure here raises rather than shipping
+            # a function that can't verify Discord's requests
             extras_dir = _layer_extras_dir(python_version, architecture)
             if extras_dir:
                 for root, dirs, files in os.walk(extras_dir):
@@ -736,10 +737,6 @@ def deploy(
             _allow_ratelimit_table(iam, role_name, table_arn)
         env = {**env, "CORDLESS_RATELIMIT_TABLE": table_name}
 
-    from . import upload as _upload
-
-    _upload.pynacl_bundle_failed = False
-
     if bundle_cordless:
         with Spinner(f"cordless  {_cordless_version()} (local)"):
             layer_arn = None
@@ -883,11 +880,7 @@ def deploy(
     summary(
         [
             (True, "Runtime", runtime),
-            (
-                not _upload.pynacl_bundle_failed,
-                "Signature verification",
-                "pynacl" if not _upload.pynacl_bundle_failed else "pure-Python Ed25519 (slower than pynacl)",
-            ),
+            (True, "Signature verification", "pynacl"),
             *package_check,
             *health,
         ]

--- a/src/cordless/upload.py
+++ b/src/cordless/upload.py
@@ -22,22 +22,11 @@ def _cordless_package_dir():
     return os.path.dirname(spec.origin)
 
 
-# Set when a fetch fails, so deploy() can warn once the spinner has stopped
-# animating instead of mid-spin, where print() gets stomped by its redraws.
-pynacl_bundle_failed = False
-
-
 def _layer_extras_dir(python_version, architecture="x86_64"):
-    """Fetch pynacl (fast Ed25519 verify) for the layer. Never fails the deploy -
-    falls back to the pure-Python verify path if the fetch doesn't work out."""
-    global pynacl_bundle_failed
+    """Fetch pynacl (required for signature verification) for the layer."""
     from .deploy import _ensure_packages
 
-    try:
-        return _ensure_packages(["pynacl"], python_version, architecture)
-    except Exception:
-        pynacl_bundle_failed = True
-        return None
+    return _ensure_packages(["pynacl"], python_version, architecture)
 
 
 def build_layer_zip(python_version=None, architecture="x86_64"):

--- a/src/cordless/verify.py
+++ b/src/cordless/verify.py
@@ -1,71 +1,5 @@
-import hashlib
-
-# PyNaCl verifies in C at ~100x the speed of the pure-Python fallback below,
-# worth real milliseconds inside Discord's 3-second window on small Lambdas.
-# Opt in by adding "pynacl" to packages in cordless.toml.
-try:
-    from nacl.exceptions import BadSignatureError
-    from nacl.signing import VerifyKey
-except ImportError:
-    VerifyKey = None
-
-# Ed25519 curve parameters (RFC 8032)
-_P = 2**255 - 19
-_L = 2**252 + 27742317777372353535851937790883648493
-_D = (-121665 * pow(121666, _P - 2, _P)) % _P
-_SQRTN1 = pow(2, (_P - 1) // 4, _P)
-# Base point compressed (y = 4/5 mod p, x positive), little-endian
-_B_BYTES = bytes.fromhex("5866666666666666666666666666666666666666666666666666666666666666")
-
-
-def _point_add(P, Q):
-    x1, y1, z1, t1 = P
-    x2, y2, z2, t2 = Q
-    a = (y1 - x1) * (y2 - x2) % _P
-    b = (y1 + x1) * (y2 + x2) % _P
-    c = 2 * t1 * t2 * _D % _P
-    d = 2 * z1 * z2 % _P
-    e, f, g, h = b - a, d - c, d + c, b + a
-    return e * f % _P, g * h % _P, f * g % _P, e * h % _P
-
-
-def _point_mul(s, P):
-    R = (0, 1, 1, 0)  # identity point in extended coordinates
-    while s > 0:
-        if s & 1:
-            R = _point_add(R, P)
-        P = _point_add(P, P)
-        s >>= 1
-    return R
-
-
-def _point_decompress(b):
-    if len(b) != 32:
-        raise ValueError("invalid point length")
-    y = int.from_bytes(b, "little")
-    sign = y >> 255
-    y &= (1 << 255) - 1
-    y2 = y * y % _P
-    x2 = (y2 - 1) * pow(_D * y2 + 1, _P - 2, _P) % _P
-    if x2 == 0:
-        if sign:
-            raise ValueError("invalid point")
-        return (0, y, 1, 0)
-    x = pow(x2, (_P + 3) // 8, _P)
-    if (x * x - x2) % _P != 0:
-        x = x * _SQRTN1 % _P
-    if (x * x - x2) % _P != 0:
-        raise ValueError("invalid point")
-    if x % 2 != sign:
-        x = _P - x
-    return (x, y, 1, x * y % _P)
-
-
-def _point_equal(P, Q):
-    return (P[0] * Q[2] - Q[0] * P[2]) % _P == 0 and (P[1] * Q[2] - Q[1] * P[2]) % _P == 0
-
-
-_B = _point_decompress(_B_BYTES)
+from nacl.exceptions import BadSignatureError
+from nacl.signing import VerifyKey
 
 
 def verify_signature(public_key, signature, timestamp, body):
@@ -85,24 +19,8 @@ def verify_signature(public_key, signature, timestamp, body):
     if len(pk_bytes) != 32 or len(sig_bytes) != 64:
         return False
 
-    if VerifyKey is not None:
-        try:
-            VerifyKey(pk_bytes).verify(f"{timestamp}{body}".encode(), sig_bytes)
-            return True
-        except (BadSignatureError, ValueError):
-            return False
-
     try:
-        A = _point_decompress(pk_bytes)
-        R = _point_decompress(sig_bytes[:32])
-    except ValueError:
+        VerifyKey(pk_bytes).verify(f"{timestamp}{body}".encode(), sig_bytes)
+        return True
+    except (BadSignatureError, ValueError):
         return False
-
-    S = int.from_bytes(sig_bytes[32:], "little")
-    if S >= _L:
-        return False
-
-    message = f"{timestamp}{body}".encode()
-    h = int.from_bytes(hashlib.sha512(sig_bytes[:32] + pk_bytes + message).digest(), "little") % _L
-
-    return _point_equal(_point_mul(S, _B), _point_add(R, _point_mul(h, A)))

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -599,34 +599,23 @@ def test_deploy_log_retention_zero_leaves_group_unset(deploy_patches, monkeypatc
 
 
 @mock_aws
-def test_deploy_warns_when_pynacl_bundle_failed(deploy_patches, monkeypatch, capsys):
-    import cordless.upload
-
+def test_deploy_fails_when_pynacl_bundle_fails(deploy_patches, monkeypatch):
     iam = boto3.client("iam", region_name=REGION)
     monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
-    cordless.upload.pynacl_bundle_failed = False
 
-    def _fresh_zip_with_pynacl_failure(*a, **kw):
-        cordless.upload.pynacl_bundle_failed = True
-        return _minimal_zip(deploy_patches)
+    def _boom(*a, **kw):
+        raise RuntimeError("no matching wheel")
 
-    monkeypatch.setattr(cordless.deploy, "build_function_zip", _fresh_zip_with_pynacl_failure)
+    monkeypatch.setattr(cordless.deploy, "build_function_zip", _boom)
 
-    url = deploy(**_base_deploy_kwargs(deploy_patches))
-
-    assert url  # deploy must still succeed, not raise
-    out = capsys.readouterr().out
-    assert "Signature verification: pure-Python Ed25519 (slower than pynacl)" in out
-    assert "⚠" in out
+    with pytest.raises(RuntimeError):
+        deploy(**_base_deploy_kwargs(deploy_patches))
 
 
 @mock_aws
-def test_deploy_summary_shows_pynacl_when_bundled(deploy_patches, monkeypatch, capsys):
-    import cordless.upload
-
+def test_deploy_summary_shows_pynacl(deploy_patches, monkeypatch, capsys):
     iam = boto3.client("iam", region_name=REGION)
     monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
-    cordless.upload.pynacl_bundle_failed = False
 
     deploy(**_base_deploy_kwargs(deploy_patches))
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -5,15 +5,7 @@ import zipfile
 
 import pytest
 
-import cordless.upload
 from cordless.deploy import _packages_cache_dir, build_function_zip, load_config
-
-
-@pytest.fixture(autouse=True)
-def _reset_pynacl_bundle_failed():
-    cordless.upload.pynacl_bundle_failed = False
-    yield
-    cordless.upload.pynacl_bundle_failed = False
 
 
 def _zip_names(zip_path):
@@ -184,26 +176,25 @@ def test_bundle_cordless_does_not_double_write_when_packages_overlaps_extras(tmp
         os.unlink(zip_path)
 
 
-def test_bundle_cordless_survives_pynacl_fetch_failure(tmp_path, monkeypatch):
+def test_bundle_cordless_fails_when_pynacl_fetch_fails(tmp_path, monkeypatch):
     import cordless.deploy
     import cordless.upload
 
     pkg_dir = tmp_path / "site-packages" / "cordless"
     _make_tree(pkg_dir, ["app.py", "__init__.py"])
     monkeypatch.setattr(cordless.upload, "_cordless_package_dir", lambda: str(pkg_dir))
-    monkeypatch.setattr(cordless.upload, "_layer_extras_dir", lambda v, arch="x86_64": None)
+
+    def boom(v, arch="x86_64"):
+        raise RuntimeError("no matching wheel")
+
+    monkeypatch.setattr(cordless.upload, "_layer_extras_dir", boom)
 
     src = tmp_path / "src"
     src.mkdir()
     (src / "lambda_function.py").write_text("x")
 
-    zip_path = cordless.deploy.build_function_zip(str(src), bundle_cordless=True)
-    try:
-        names = _zip_names(zip_path)
-        assert any(n.startswith("cordless/") for n in names)
-        assert not any("/nacl/" in n or n.startswith("nacl/") for n in names)
-    finally:
-        os.unlink(zip_path)
+    with pytest.raises(RuntimeError):
+        cordless.deploy.build_function_zip(str(src), bundle_cordless=True)
 
 
 def test_bundle_cordless_includes_egg_info(tmp_path, monkeypatch):
@@ -334,21 +325,19 @@ def test_layer_zip_does_not_double_write_overlapping_names(tmp_path, monkeypatch
         os.unlink(zip_path)
 
 
-def test_layer_zip_survives_pynacl_fetch_failure(monkeypatch):
+def test_layer_zip_fails_when_pynacl_fetch_fails(monkeypatch):
     import cordless.upload
 
-    monkeypatch.setattr(cordless.upload, "_layer_extras_dir", lambda v, arch="x86_64": None)
+    def boom(v, arch="x86_64"):
+        raise RuntimeError("no matching wheel")
 
-    zip_path = cordless.upload.build_layer_zip("3.12")
-    try:
-        names = _zip_names(zip_path)
-        assert any(n.startswith("python/cordless/") for n in names)
-        assert not any("/nacl/" in n for n in names)
-    finally:
-        os.unlink(zip_path)
+    monkeypatch.setattr(cordless.upload, "_layer_extras_dir", boom)
+
+    with pytest.raises(RuntimeError):
+        cordless.upload.build_layer_zip("3.12")
 
 
-def test_layer_extras_dir_returns_none_when_fetch_fails(monkeypatch):
+def test_layer_extras_dir_raises_when_fetch_fails(monkeypatch):
     import cordless.deploy
     import cordless.upload
 
@@ -357,8 +346,8 @@ def test_layer_extras_dir_returns_none_when_fetch_fails(monkeypatch):
 
     monkeypatch.setattr(cordless.deploy, "_ensure_packages", boom)
 
-    assert cordless.upload._layer_extras_dir("3.12") is None
-    assert cordless.upload.pynacl_bundle_failed is True
+    with pytest.raises(RuntimeError):
+        cordless.upload._layer_extras_dir("3.12")
 
 
 def test_layer_zip_without_runtime_skips_extras(monkeypatch):

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -102,46 +102,10 @@ def test_base64_encoded_body_is_decoded_before_verification():
     assert result["statusCode"] == 200
 
 
-def test_pure_python_fallback_accepts_valid_signature(monkeypatch):
+def test_nacl_is_required():
     import cordless.verify
 
-    monkeypatch.setattr(cordless.verify, "VerifyKey", None)
-
-    signing_key = SigningKey.generate()
-    public_key = signing_key.verify_key.encode().hex()
-
-    bot = Cordless(public_key=public_key)
-    body = json.dumps({"type": 1})
-
-    result = bot.handle(_signed_event(signing_key, body))
-    assert result["statusCode"] == 200
-
-
-def test_pure_python_fallback_rejects_invalid_signature(monkeypatch):
-    import cordless.verify
-
-    monkeypatch.setattr(cordless.verify, "VerifyKey", None)
-
-    signing_key = SigningKey.generate()
-    public_key = signing_key.verify_key.encode().hex()
-
-    bot = Cordless(public_key=public_key)
-    event = {
-        "headers": {
-            "X-Signature-Ed25519": "00" * 64,
-            "X-Signature-Timestamp": "1234567890",
-        },
-        "body": json.dumps({"type": 1}),
-    }
-
-    result = bot.handle(event)
-    assert result["statusCode"] == 401
-
-
-def test_nacl_fast_path_is_active_when_installed():
-    import cordless.verify
-
-    assert cordless.verify.VerifyKey is not None  # pynacl is a dev dep, fast path must be wired
+    assert cordless.verify.VerifyKey is not None
 
 
 def test_no_public_key_skips_verification():

--- a/uv.lock
+++ b/uv.lock
@@ -271,6 +271,7 @@ source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "botocore", extra = ["crt"] },
+    { name = "pynacl" },
     { name = "uv" },
 ]
 
@@ -289,6 +290,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.20" },
     { name = "botocore", extras = ["crt"] },
+    { name = "pynacl", specifier = ">=1.5" },
     { name = "uv", specifier = ">=0.11" },
 ]
 


### PR DESCRIPTION
## Summary

- Removes the pure-Python Ed25519 fallback in `verify.py`; signature verification now requires `pynacl` unconditionally, no silent slow path.
- Deploy now fails outright if `pynacl` cannot be fetched/bundled into the layer, instead of warning and shipping a function that would silently fall back at runtime.
- Promotes `pynacl` from a dev-only dependency to a core dependency, since `verify.py` now imports it unconditionally, including for local `cordless dev` usage.

## Why

The pure-Python fallback existed so a bot would still work if `pynacl`'s compiled wheel couldn't be fetched for a given runtime/architecture, at the cost of a much slower, hand-rolled Ed25519 verify path. Given `pynacl` is the correct implementation to run in production, this removes the fallback entirely: either the fast path is available, or the deploy/import fails loudly rather than degrading silently.