### PR TITLE
feat: added http routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ cordless flips this. Your bot is a Lambda function: it only runs when Discord se
 - **Local dev:** `cordless dev` runs your bot on localhost with a live public tunnel
 - **Slow commands:** deferred interactions hand off to a worker Lambda so Discord's 3-second limit is never a problem
 - **Full REST API:** every Discord endpoint, typed, reachable as `bot.<verb>()` or directly on the objects you already have (`guild.create_channel()`, `message.reply()`)
+- **Raw HTTP routes:** `@bot.route("POST", "/stripe/webhook")` handles third-party webhooks, OAuth callbacks and health checks on the same function, outside Discord's interaction flow
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,7 +32,7 @@ The current feature surface, for orientation:
 - `cordless dev`: local hot-reload server with an optional cloudflared
   public tunnel
 - `bot.route(method, path)`: raw HTTP handlers on the same Lambda, outside
-  the Discord interaction flow, for third-party webhooks (Stripe, GitHub),
+  the Discord interaction flow, for incoming webhooks from other services,
   OAuth redirect callbacks, and health checks. The handler gets the raw
   event and the `bot` instance, so it can reuse `send_message`,
   `execute_webhook`, and the rest. Paths take `{name}` segments. Works on

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,6 +31,13 @@ The current feature surface, for orientation:
 - File uploads / multipart attachments
 - `cordless dev`: local hot-reload server with an optional cloudflared
   public tunnel
+- `bot.route(method, path)`: raw HTTP handlers on the same Lambda, outside
+  the Discord interaction flow, for third-party webhooks (Stripe, GitHub),
+  OAuth redirect callbacks, and health checks. The handler gets the raw
+  event and the `bot` instance, so it can reuse `send_message`,
+  `execute_webhook`, and the rest. Paths take `{name}` segments. Requires
+  `endpoint = "api_gateway"`; `cordless deploy` diffs the routes onto the
+  API the same way it diffs Discord commands
 - `cordless deploy`: Function URL or API Gateway (custom domain), IAM role,
   command registration, all in one command; `cordless destroy` to tear down
 - Environment-specific config (`--environment`/`--env`, overlay `.env` files)
@@ -70,16 +77,6 @@ N/A
   to live in their own IaC instead of being managed imperatively by the CLI.
 - Starter templates (`cordless init --template moderation`, `--template
   economy`, ...).
-- `bot.route(method, path)`: register raw HTTP routes on the same Lambda,
-  outside the Discord interaction flow, with the handler getting the raw
-  event and the `bot` instance (so it can reuse `send_message`,
-  `execute_webhook`, etc.). For anything that needs to land on the same
-  function without going through Discord signature verification: third-party
-  webhooks (Stripe, GitHub, ...), OAuth redirect callbacks, health checks.
-  Only viable under `endpoint = "api_gateway"`, since Function URLs are
-  single-path; `deploy` would need to diff/sync these routes the same way it
-  already diffs/syncs Discord commands, rather than requiring a hand-rolled
-  boto3 script like today.
 
 ## Non-goals (for now)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,9 +35,9 @@ The current feature surface, for orientation:
   the Discord interaction flow, for third-party webhooks (Stripe, GitHub),
   OAuth redirect callbacks, and health checks. The handler gets the raw
   event and the `bot` instance, so it can reuse `send_message`,
-  `execute_webhook`, and the rest. Paths take `{name}` segments. Requires
-  `endpoint = "api_gateway"`; `cordless deploy` diffs the routes onto the
-  API the same way it diffs Discord commands
+  `execute_webhook`, and the rest. Paths take `{name}` segments. Works on
+  either endpoint; `endpoint = "api_gateway"` additionally gives edge 404s
+  for unknown paths and deploy-time route sync
 - `cordless deploy`: Function URL or API Gateway (custom domain), IAM role,
   command registration, all in one command; `cordless destroy` to tear down
 - Environment-specific config (`--environment`/`--env`, overlay `.env` files)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ include = [
     "src/cordless/models.py",
     "src/cordless/app.py",
     "src/cordless/router.py",
+    "src/cordless/routes.py",
     "src/cordless/webhook.py",
     "src/cordless/_multipart.py",
     "src/cordless/errors.py",

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -691,6 +691,33 @@ class Cordless(RESTMixin):
 
         return decorator
 
+    def route(self, method, path):
+        """Register a raw HTTP handler on the same Lambda, outside the
+        Discord interaction flow.
+
+        Use it for requests that must reach this function without Discord
+        signature verification: third-party webhooks (Stripe, GitHub),
+        OAuth redirect callbacks, health checks. The handler is called as
+        `handler(event, bot)` with the raw Lambda event and this instance,
+        so it can reuse `send_message`, `execute_webhook`, and the rest.
+
+        `path` may contain `{name}` segments; matched values arrive on
+        `event["pathParameters"]`. A trailing `{name+}` captures the rest of
+        the path. The handler may return a string, a dict or list (sent as
+        JSON), a status int, a `(status, body)` or `(status, body, headers)`
+        tuple, or a full Lambda proxy dict.
+
+        Only works with `endpoint = "api_gateway"`, since a Function URL
+        serves a single path. `cordless deploy` syncs these routes onto the
+        API alongside the Discord commands.
+        """
+
+        def decorator(func):
+            self.router.register_route(method, path, func)
+            return func
+
+        return decorator
+
     def error(self, func):
         """Register the error handler, called as `(ctx, exc)`. If it sends a
         response (or returns one), that becomes the interaction's response;
@@ -716,6 +743,11 @@ class Cordless(RESTMixin):
         `handler()` instead, which wraps this plus keep-warm pings and
         `@bot.cron` dispatch, call this directly only if you're building a
         custom Lambda entrypoint."""
+        if self.router.routes:
+            response = self._try_route(event)
+            if response is not None:
+                return response
+
         body = _extract_body(event)
 
         # None means verification is deliberately off (local/testing); an empty
@@ -743,6 +775,35 @@ class Cordless(RESTMixin):
         except CordlessError as exc:
             print(f"[cordless] {exc.__class__.__name__}: {exc}")
             return _json_response(400, {"error": str(exc)})
+
+    def _try_route(self, event):
+        """Dispatch `event` to a matching `@bot.route` handler. Returns the
+        response dict, or `None` when the event is a Discord interaction and
+        should fall through to the normal path."""
+        from .routes import build_response, request_method_path
+
+        method, path = request_method_path(event)
+        if method is None or (method == "POST" and path == "/"):
+            return None
+
+        match = self.router.match_route(method, path)
+        if match is None:
+            return _json_response(404, {"error": f"no route for {method} {path}"})
+
+        handler, params = match
+        route_event = dict(event)
+        route_event["pathParameters"] = {**(event.get("pathParameters") or {}), **params}
+        try:
+            result = asyncio.run(handler(route_event, self))
+        except CordlessError as exc:
+            print(f"[cordless] {exc.__class__.__name__}: {exc}")
+            return _json_response(400, {"error": str(exc)})
+        except Exception:
+            import traceback
+
+            traceback.print_exc()
+            return _json_response(500, {"error": "route handler raised an exception"})
+        return build_response(result)
 
     def load_extension(self, name: str) -> None:
         """Load a cog module by dotted path (e.g. 'cogs.game').
@@ -830,6 +891,8 @@ class Cordless(RESTMixin):
                 self.router.register_modal(kwargs["custom_id"], func)
             elif ctype == "autocomplete":
                 self.router.register_autocomplete(kwargs["cmd_name"], kwargs["option_name"], func)
+            elif ctype == "route":
+                self.router.register_route(kwargs["method"], kwargs["path"], func)
             elif ctype == "user_command":
                 self.router.register_command(
                     kwargs["name"],

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -744,8 +744,8 @@ class Cordless(RESTMixin):
         Discord interaction flow.
 
         Use it for requests that must reach this function without Discord
-        signature verification: third-party webhooks (Stripe, GitHub),
-        OAuth redirect callbacks, health checks. The handler is called as
+        signature verification: incoming webhooks from other services, OAuth
+        redirect callbacks, health checks. The handler is called as
         `handler(event, bot)` with the raw Lambda event and this instance,
         so it can reuse `send_message`, `execute_webhook`, and the rest.
 

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -838,6 +838,10 @@ class Cordless(RESTMixin):
 
         match = self.router.match_route(method, path)
         if match is None:
+            # an unmatched POST may still be a Discord interaction whose
+            # endpoint URL carries a path, so fall through to handle()
+            if method == "POST":
+                return None
             return _json_response(404, {"error": f"no route for {method} {path}"})
 
         handler, params = match

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -44,11 +44,58 @@ def _prewarm_defer():
         pass
 
 
+_MAX_OPTIONS = 25
+_MAX_CHOICES = 25
+
+
 def _validate_command_name(name):
     """Fail at decoration time instead of with a cryptic Discord API error at register time."""
     for part in name.split("/"):
         if not _NAME_RE.fullmatch(part):
             raise ValueError(f"Invalid command name {name!r}: Discord requires 1-32 lowercase letters, digits, - or _")
+
+
+def _check_description(where, text):
+    """Discord requires a 1 to 100 character description on chat-input
+    commands and every option. An empty or overlong one is otherwise only
+    caught by a positional Invalid Form Body error at register time."""
+    length = 0 if text is None else len(text)
+    if not 1 <= length <= 100:
+        raise ValueError(f"{where}: description must be 1 to 100 characters, got {length}")
+
+
+def _validate_command_shape(name, description, options, group_description=None):
+    """Decoration-time checks for the static limits that produce opaque
+    Discord errors: description lengths, option names, and the 25-item caps
+    on options and choices. Every message names the command."""
+    _check_description(f"Command {name!r}", description)
+    if group_description is not None:
+        _check_description(f"Command {name!r} group", group_description)
+
+    if len(options) > _MAX_OPTIONS:
+        raise ValueError(f"Command {name!r} has {len(options)} options, Discord allows at most {_MAX_OPTIONS}")
+
+    for opt in options:
+        opt_name = opt.get("name", "")
+        if not _NAME_RE.fullmatch(opt_name):
+            raise ValueError(
+                f"Command {name!r}: invalid option name {opt_name!r}, "
+                "Discord requires 1-32 lowercase letters, digits, - or _"
+            )
+        _check_description(f"Command {name!r} option {opt_name!r}", opt.get("description"))
+
+        choices = opt.get("choices") or []
+        if len(choices) > _MAX_CHOICES:
+            raise ValueError(
+                f"Command {name!r} option {opt_name!r} has {len(choices)} choices, "
+                f"Discord allows at most {_MAX_CHOICES}"
+            )
+        for ch in choices:
+            ch_name = ch.get("name")
+            if ch_name is None or not 1 <= len(str(ch_name)) <= 100:
+                raise ValueError(
+                    f"Command {name!r} option {opt_name!r}: choice name must be 1 to 100 characters, got {ch_name!r}"
+                )
 
 
 def _unwrap_optional(annotation):
@@ -249,6 +296,7 @@ class Cordless(RESTMixin):
 
         def decorator(func):
             _options = options if options is not None else options_from_signature(func)
+            _validate_command_shape(name, description, _options, group_description)
             if defer:
                 func._defer = True
                 if ephemeral:
@@ -857,6 +905,9 @@ class Cordless(RESTMixin):
                 resolved_options = kwargs["options"]
                 if resolved_options is None:
                     resolved_options = options_from_signature(func)
+                _validate_command_shape(
+                    kwargs["name"], kwargs["description"], resolved_options, kwargs.get("group_description")
+                )
                 self.router.register_command(
                     kwargs["name"],
                     func,

--- a/src/cordless/app.py
+++ b/src/cordless/app.py
@@ -755,9 +755,11 @@ class Cordless(RESTMixin):
         JSON), a status int, a `(status, body)` or `(status, body, headers)`
         tuple, or a full Lambda proxy dict.
 
-        Only works with `endpoint = "api_gateway"`, since a Function URL
-        serves a single path. `cordless deploy` syncs these routes onto the
-        API alongside the Discord commands.
+        Works on either endpoint. On the default Function URL every path
+        reaches the function and cordless does the matching. Setting
+        `endpoint = "api_gateway"` adds edge 404s for unknown paths and
+        makes `cordless deploy` sync these routes onto the API alongside the
+        Discord commands.
         """
 
         def decorator(func):

--- a/src/cordless/cli.py
+++ b/src/cordless/cli.py
@@ -523,6 +523,7 @@ def _doctor(args):
     bot_target = _resolve_bot(args.bot, source_dir, cfg)
     bot = _load_bot(bot_target, path=source_dir) if bot_target else None
     crons = {name: entry["schedule"] for name, entry in bot.crons.items()} if bot else None
+    routes = bot.router.route_defs() if bot else None
 
     from ._progress import _DIM, _RESET
 
@@ -539,6 +540,7 @@ def _doctor(args):
         keep_warm=keep_warm,
         ratelimit=ratelimit,
         local_env=local_env,
+        routes=routes,
         on_section=_print_as_it_goes,
     )
     print(f"\n  {_DIM}── done ──{_RESET}\n")

--- a/src/cordless/cli.py
+++ b/src/cordless/cli.py
@@ -200,6 +200,7 @@ def _deploy(args):
     bot_target = _resolve_bot(None, source_dir, cfg)
     bot = _load_bot(bot_target, path=source_dir) if bot_target else None
     crons = {name: entry["schedule"] for name, entry in bot.crons.items()} if bot else None
+    routes = bot.router.route_defs() if bot else None
 
     deploy(
         function_name=function_name,
@@ -226,6 +227,7 @@ def _deploy(args):
         endpoint=args.endpoint or cfg.get("endpoint"),
         keep_warm=cfg.get("keep-warm"),
         log_retention_days=int(cfg.get("log_retention", _DEFAULT_LOG_RETENTION_DAYS)),
+        routes=routes,
     )
 
     if args.register:

--- a/src/cordless/cog.py
+++ b/src/cordless/cog.py
@@ -102,6 +102,15 @@ class Cog:
 
         return decorator
 
+    def route(self, method, path):
+        """Same as `Cordless.route`."""
+
+        def decorator(func):
+            self._handlers.append(("route", func, {"method": method, "path": path}))
+            return func
+
+        return decorator
+
     def autocomplete(self, cmd_name, option_name):
         """Same as `Cordless.autocomplete`."""
 

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -508,6 +508,14 @@ def _ensure_integration(apigw, api_id, function_arn):
     )["IntegrationId"]
 
 
+def _api_route_key(method, path):
+    """AWS HTTP APIs only accept {proxy+} for the greedy segment; cordless
+    allows any name and resolves it from its own matcher, so rewrite it
+    just for the wire key."""
+    wire_path = re.sub(r"\{[^/}]+\+\}", "{proxy+}", path)
+    return f"{method} {wire_path}"
+
+
 def _ensure_api_gateway(apigw, lam, function_name, function_arn, region, account_id, routes=None):
     api_name = f"{function_name}-api"
 
@@ -528,13 +536,15 @@ def _ensure_api_gateway(apigw, lam, function_name, function_arn, region, account
     target = f"integrations/{integration_id}"
 
     # POST / is Discord's interaction endpoint; the rest come from @bot.route.
-    # Sync them like slash commands: create the missing, drop the stale.
-    wanted = {"POST /"} | {f"{method} {path}" for method, path in (routes or [])}
+    # Sync them like slash commands: create the missing, drop the stale. When
+    # routes is None the bot never loaded, so ensure POST / but prune nothing.
+    wanted = {"POST /"} | {_api_route_key(method, path) for method, path in (routes or [])}
     present = {r["RouteKey"]: r["RouteId"] for r in _list_all_routes(apigw, api_id)}
     for key in wanted - set(present):
         apigw.create_route(ApiId=api_id, RouteKey=key, Target=target)
-    for key in set(present) - wanted:
-        apigw.delete_route(ApiId=api_id, RouteId=present[key])
+    if routes is not None:
+        for key in set(present) - wanted:
+            apigw.delete_route(ApiId=api_id, RouteId=present[key])
 
     # Always refresh the Lambda invoke permission for this API
     source_arn = f"arn:aws:execute-api:{region}:{account_id}:{api_id}/*/*"
@@ -971,7 +981,7 @@ def _health_check(
             checks.append((api is not None, "API Gateway", "present" if api else "not found"))
             if api is not None and routes:
                 have = {r["RouteKey"] for r in _list_all_routes(apigw, api["ApiId"])}
-                want = {"POST /"} | {f"{method} {path}" for method, path in routes}
+                want = {"POST /"} | {_api_route_key(method, path) for method, path in routes}
                 missing = want - have
                 detail = "all present" if not missing else f"missing: {', '.join(sorted(missing))}"
                 checks.append((not missing, "API routes", detail))

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -401,6 +401,10 @@ def _list_all_layer_versions(lam, layer_name):
     return paginator.paginate(LayerName=layer_name).build_full_result()["LayerVersions"]
 
 
+def _list_all_routes(apigw, api_id):
+    return apigw.get_paginator("get_routes").paginate(ApiId=api_id).build_full_result()["Items"]
+
+
 def _list_all_rules(events, prefix):
     return events.get_paginator("list_rules").paginate(NamePrefix=prefix).build_full_result()["Rules"]
 
@@ -490,7 +494,21 @@ def _update_function(
     lam.get_waiter("function_updated").wait(FunctionName=function_name)
 
 
-def _ensure_api_gateway(apigw, lam, function_name, function_arn, region, account_id):
+def _ensure_integration(apigw, api_id, function_arn):
+    """Return the id of this API's AWS_PROXY integration to the function,
+    creating it if absent. Every route shares the one integration."""
+    for integration in apigw.get_integrations(ApiId=api_id).get("Items", []):
+        if integration.get("IntegrationUri") == function_arn:
+            return integration["IntegrationId"]
+    return apigw.create_integration(
+        ApiId=api_id,
+        IntegrationType="AWS_PROXY",
+        IntegrationUri=function_arn,
+        PayloadFormatVersion="2.0",
+    )["IntegrationId"]
+
+
+def _ensure_api_gateway(apigw, lam, function_name, function_arn, region, account_id, routes=None):
     api_name = f"{function_name}-api"
 
     # Reuse existing API if one with this name exists
@@ -504,21 +522,19 @@ def _ensure_api_gateway(apigw, lam, function_name, function_arn, region, account
         api = apigw.create_api(Name=api_name, ProtocolType="HTTP")
         api_id = api["ApiId"]
         endpoint = api["ApiEndpoint"]
-
-        integration = apigw.create_integration(
-            ApiId=api_id,
-            IntegrationType="AWS_PROXY",
-            IntegrationUri=function_arn,
-            PayloadFormatVersion="2.0",
-        )
-
-        apigw.create_route(
-            ApiId=api_id,
-            RouteKey="POST /",
-            Target=f"integrations/{integration['IntegrationId']}",
-        )
-
         apigw.create_stage(ApiId=api_id, StageName="$default", AutoDeploy=True)
+
+    integration_id = _ensure_integration(apigw, api_id, function_arn)
+    target = f"integrations/{integration_id}"
+
+    # POST / is Discord's interaction endpoint; the rest come from @bot.route.
+    # Sync them like slash commands: create the missing, drop the stale.
+    wanted = {"POST /"} | {f"{method} {path}" for method, path in (routes or [])}
+    present = {r["RouteKey"]: r["RouteId"] for r in _list_all_routes(apigw, api_id)}
+    for key in wanted - set(present):
+        apigw.create_route(ApiId=api_id, RouteKey=key, Target=target)
+    for key in set(present) - wanted:
+        apigw.delete_route(ApiId=api_id, RouteId=present[key])
 
     # Always refresh the Lambda invoke permission for this API
     source_arn = f"arn:aws:execute-api:{region}:{account_id}:{api_id}/*/*"
@@ -688,6 +704,7 @@ def deploy(
     endpoint=None,
     keep_warm=None,
     log_retention_days=_DEFAULT_LOG_RETENTION_DAYS,
+    routes=None,
 ):
     if not function_name:
         raise SystemExit("Function name is required: pass --function or set [deploy] function in cordless.toml")
@@ -720,8 +737,15 @@ def deploy(
             endpoint = "function_url"
         elif _has_api_gateway(apigw, function_name):
             endpoint = "api_gateway"
+        elif routes:
+            endpoint = "api_gateway"
         else:
             endpoint = "function_url"
+
+    if routes and endpoint == "function_url":
+        raise SystemExit(
+            'bot.route() needs endpoint = "api_gateway" in cordless.toml; a Function URL serves a single path'
+        )
 
     print()
 
@@ -791,7 +815,7 @@ def deploy(
                 url = _ensure_function_url(lam, function_name)
         else:
             with Spinner("API Gateway"):
-                url = _ensure_api_gateway(apigw, lam, function_name, function_arn, region, account_id)
+                url = _ensure_api_gateway(apigw, lam, function_name, function_arn, region, account_id, routes=routes)
 
         if defer_worker:
             w_exists, worker_arn = _function_exists(lam, defer_worker)
@@ -862,6 +886,7 @@ def deploy(
         keep_warm,
         ratelimit,
         table_name,
+        routes,
     )
 
     missing_packages = scan_missing_packages(source_dir, packages)
@@ -905,6 +930,7 @@ def _health_check(
     keep_warm,
     ratelimit,
     table_name,
+    routes=None,
 ):
     """Describe-only post-deploy checks - no invocations, no AWS cost. Confirms
     the pieces deploy() just wired are actually present and in the expected
@@ -945,8 +971,14 @@ def _health_check(
     else:
         try:
             api_name = f"{function_name}-api"
-            exists = any(a["Name"] == api_name for a in _list_all_apis(apigw))
-            checks.append((exists, "API Gateway", "present" if exists else "not found"))
+            api = next((a for a in _list_all_apis(apigw) if a["Name"] == api_name), None)
+            checks.append((api is not None, "API Gateway", "present" if api else "not found"))
+            if api is not None and routes:
+                have = {r["RouteKey"] for r in _list_all_routes(apigw, api["ApiId"])}
+                want = {"POST /"} | {f"{method} {path}" for method, path in routes}
+                missing = want - have
+                detail = "all present" if not missing else f"missing: {', '.join(sorted(missing))}"
+                checks.append((not missing, "API routes", detail))
         except Exception as exc:
             checks.append((False, "API Gateway", f"could not verify ({exc})"))
 

--- a/src/cordless/deploy.py
+++ b/src/cordless/deploy.py
@@ -732,20 +732,16 @@ def deploy(
 
     if endpoint is None:
         # keep whichever endpoint an existing function already has; only a
-        # brand new function gets the simpler, lower-latency default
+        # brand new function gets the simpler, lower-latency default.
+        # bot.route works on either: dispatch reads the same payload-format-2.0
+        # event either way. api_gateway just adds edge 404s for unknown paths
+        # and deploy-time route sync, so switching to it stays an opt-in.
         if _has_function_url(lam, function_name):
             endpoint = "function_url"
         elif _has_api_gateway(apigw, function_name):
             endpoint = "api_gateway"
-        elif routes:
-            endpoint = "api_gateway"
         else:
             endpoint = "function_url"
-
-    if routes and endpoint == "function_url":
-        raise SystemExit(
-            'bot.route() needs endpoint = "api_gateway" in cordless.toml; a Function URL serves a single path'
-        )
 
     print()
 
@@ -981,6 +977,12 @@ def _health_check(
                 checks.append((not missing, "API routes", detail))
         except Exception as exc:
             checks.append((False, "API Gateway", f"could not verify ({exc})"))
+
+    if routes and endpoint == "function_url":
+        # nothing to verify against AWS: on a Function URL every path reaches
+        # the handler and cordless does the matching, so just list them
+        listed = ", ".join(f"{method} {path}" for method, path in routes)
+        checks.append((True, "HTTP routes", f"{len(routes)} served on the function URL: {listed}"))
 
     if crons:
         target = defer_worker or function_name

--- a/src/cordless/dev.py
+++ b/src/cordless/dev.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import threading
 import time
+import urllib.parse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 from ._progress import _DIM, _GREEN, _RED, _RESET, _YELLOW, Spinner, _tty
@@ -165,22 +166,42 @@ def _load_env(source_dir, environment=None):
 
 def _make_handler(reloader, verbose=False):
     class DevHandler(BaseHTTPRequestHandler):
-        def do_GET(self):
-            body = b"cordless dev is running \xe2\x9c\x93"
-            self.send_response(200)
-            self.send_header("Content-Type", "text/plain; charset=utf-8")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
+        def _serve(self):
+            split = urllib.parse.urlsplit(self.path)
+            path = "/" + "/".join(s for s in split.path.split("/") if s)
+            method = self.command
+            bot = reloader.get()
 
-        def do_POST(self):
+            # keep the friendly landing page when nothing claims GET /
+            if method == "GET" and path == "/" and bot.router.match_route("GET", "/") is None:
+                body = b"cordless dev is running \xe2\x9c\x93"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+
             length = int(self.headers.get("Content-Length", 0))
-            body = self.rfile.read(length).decode()
-            event = {"body": body, "headers": dict(self.headers)}
+            raw = self.rfile.read(length) if length else b""
+            try:
+                body = raw.decode()
+            except UnicodeDecodeError:
+                body = base64.b64encode(raw).decode()
+            query = {k: v[-1] for k, v in urllib.parse.parse_qs(split.query).items()}
+            event = {
+                "body": body,
+                "headers": dict(self.headers),
+                "rawPath": path,
+                "rawQueryString": split.query,
+                "queryStringParameters": query or None,
+                "requestContext": {"http": {"method": method, "path": path}},
+                "isBase64Encoded": False,
+            }
 
             start = time.perf_counter()
             try:
-                result = reloader.get().handle(event)
+                result = bot.handle(event)
             except Exception as exc:
                 import traceback
 
@@ -203,15 +224,17 @@ def _make_handler(reloader, verbose=False):
             self.end_headers()
             self.wfile.write(payload)
 
-            _log_request(_describe_interaction(body), result["statusCode"], elapsed_ms, body, verbose=verbose)
+            label = _describe_interaction(body) if method == "POST" and path == "/" else f"{method} {path}"
+            _log_request(label, result["statusCode"], elapsed_ms, body, verbose=verbose)
+
+        do_GET = _serve
+        do_POST = _serve
+        do_PUT = _serve
+        do_PATCH = _serve
+        do_DELETE = _serve
 
         def log_message(self, fmt, *args):
-            if self.command == "POST":
-                return  # do_POST already logged a richer line above
-            status = args[1] if len(args) > 1 else ""
-            dim = _DIM if _tty else ""
-            reset = _RESET if _tty else ""
-            print(f"  {dim}{_timestamp()}{reset} → {self.command} {status}")
+            return  # _serve already logs a richer line
 
     return DevHandler
 

--- a/src/cordless/dev.py
+++ b/src/cordless/dev.py
@@ -172,22 +172,27 @@ def _make_handler(reloader, verbose=False):
             method = self.command
             bot = reloader.get()
 
-            # keep the friendly landing page when nothing claims GET /
-            if method == "GET" and path == "/" and bot.router.match_route("GET", "/") is None:
+            # keep the friendly landing page for GET / and, on a bot with no
+            # HTTP routes at all, for any other unclaimed GET path too
+            banner_get = path == "/" or not bot.router.routes
+            if method == "GET" and banner_get and bot.router.match_route("GET", path) is None:
                 body = b"cordless dev is running \xe2\x9c\x93"
                 self.send_response(200)
                 self.send_header("Content-Type", "text/plain; charset=utf-8")
                 self.send_header("Content-Length", str(len(body)))
                 self.end_headers()
                 self.wfile.write(body)
+                _log_request(f"{method} {path}", 200, 0.0, "", verbose=verbose)
                 return
 
             length = int(self.headers.get("Content-Length", 0))
             raw = self.rfile.read(length) if length else b""
             try:
                 body = raw.decode()
+                encoded = False
             except UnicodeDecodeError:
                 body = base64.b64encode(raw).decode()
+                encoded = True
             query = {k: v[-1] for k, v in urllib.parse.parse_qs(split.query).items()}
             event = {
                 "body": body,
@@ -196,7 +201,7 @@ def _make_handler(reloader, verbose=False):
                 "rawQueryString": split.query,
                 "queryStringParameters": query or None,
                 "requestContext": {"http": {"method": method, "path": path}},
-                "isBase64Encoded": False,
+                "isBase64Encoded": encoded,
             }
 
             start = time.perf_counter()
@@ -216,7 +221,12 @@ def _make_handler(reloader, verbose=False):
             body_out = result.get("body", "")
             # mirrors API Gateway's Lambda proxy integration: a base64Encoded
             # body carries binary data (e.g. multipart file attachments)
-            payload = base64.b64decode(body_out) if result.get("isBase64Encoded") else body_out.encode()
+            if result.get("isBase64Encoded"):
+                payload = base64.b64decode(body_out)
+            elif isinstance(body_out, (bytes, bytearray)):
+                payload = bytes(body_out)
+            else:
+                payload = body_out.encode()
             self.send_response(result["statusCode"])
             for key, value in result.get("headers", {}).items():
                 self.send_header(key, value)

--- a/src/cordless/doctor.py
+++ b/src/cordless/doctor.py
@@ -144,7 +144,18 @@ def check_env_drift(lam, function_name, local_env):
 
 
 def check_deployed_function(
-    lam, apigw, events, dynamodb, function_name, defer_worker, crons, keep_warm, ratelimit, table_name, local_env
+    lam,
+    apigw,
+    events,
+    dynamodb,
+    function_name,
+    defer_worker,
+    crons,
+    keep_warm,
+    ratelimit,
+    table_name,
+    local_env,
+    routes=None,
 ):
     from .deploy import _function_exists, _has_api_gateway, _has_function_url, _health_check
 
@@ -160,7 +171,18 @@ def check_deployed_function(
         endpoint = "function_url"
 
     health = _health_check(
-        lam, apigw, events, dynamodb, function_name, defer_worker, endpoint, crons, keep_warm, ratelimit, table_name
+        lam,
+        apigw,
+        events,
+        dynamodb,
+        function_name,
+        defer_worker,
+        endpoint,
+        crons,
+        keep_warm,
+        ratelimit,
+        table_name,
+        routes,
     )
     checks = [("ok" if ok else "fail", label, detail) for ok, label, detail in health]
     checks.extend(check_env_drift(lam, function_name, local_env))
@@ -176,6 +198,7 @@ def run(
     keep_warm=None,
     ratelimit=False,
     local_env=None,
+    routes=None,
     on_section=None,
 ):
     """Run every diagnostic check, one section at a time. Returns (sections, ok):
@@ -233,6 +256,7 @@ def run(
                 ratelimit,
                 table_name,
                 local_env,
+                routes,
             ),
         )
     _emit("Lambda", lambda_checks)

--- a/src/cordless/register.py
+++ b/src/cordless/register.py
@@ -92,4 +92,50 @@ def sync_commands(commands, guild_id=None, bot_token=None, client_id=None, clien
         with urllib.request.urlopen(request) as response:
             return json.loads(response.read())
     except urllib.error.HTTPError as exc:
-        raise RuntimeError(f"Failed to register commands ({exc.code}): {exc.read().decode()}") from exc
+        body = exc.read().decode()
+        raise RuntimeError(
+            f"Failed to register commands ({exc.code}): {_explain_form_errors(body, commands) or body}"
+        ) from exc
+
+
+def _explain_form_errors(body, commands):
+    """Rewrite Discord's positional Invalid Form Body errors (`errors.0.
+    options.18.description`) into lines that name the command and option at
+    fault. Returns None when the body is not that shape."""
+    try:
+        errors = json.loads(body).get("errors")
+    except (ValueError, AttributeError):
+        return None
+    if not isinstance(errors, dict):
+        return None
+
+    lines = []
+
+    def walk(node, defn, trail):
+        if not isinstance(node, dict):
+            return
+        leaf = node.get("_errors")
+        if isinstance(leaf, list) and leaf:
+            message = "; ".join(item.get("message", "") for item in leaf)
+            lines.append(f"{', '.join(trail)}: {message}" if trail else message)
+            return
+        for key, child in node.items():
+            if key == "_errors":
+                continue
+            if key.isdigit() and isinstance(defn, list):
+                index = int(key)
+                item = defn[index] if index < len(defn) else None
+                if not isinstance(item, dict) or "name" not in item:
+                    walk(child, item, trail + [f"[{key}]"])
+                elif not trail:
+                    walk(child, item, [f"command {item['name']!r}"])
+                else:
+                    label = {1: "subcommand", 2: "group"}.get(item.get("type"), "option")
+                    walk(child, item, trail + [f"{label} {item['name']!r}"])
+            elif key in ("options", "choices") and isinstance(defn, dict):
+                walk(child, defn.get(key), trail)
+            else:
+                walk(child, defn.get(key) if isinstance(defn, dict) else None, trail + [key])
+
+    walk(errors, commands, [])
+    return "; ".join(lines) or None

--- a/src/cordless/router.py
+++ b/src/cordless/router.py
@@ -10,6 +10,8 @@ from .errors import (
     UnknownModalError,
     UnsupportedInteractionError,
 )
+from .routes import compile_pattern, match_pattern, patterns_conflict, specificity
+from .routes import normalize as _normalize_route
 
 PING = 1
 APPLICATION_COMMAND = 2
@@ -39,6 +41,7 @@ class Router:
         self.selects = {}
         self.modals = {}
         self.autocompletes = {}  # (cmd_key, option_name) → handler
+        self.routes = []  # raw HTTP routes: {method, path, pattern, handler}
         self._error_handler = None
 
     def register_command(
@@ -101,6 +104,36 @@ class Router:
 
     def register_autocomplete(self, cmd_name, option_name, handler):
         self.autocompletes[(cmd_name, option_name)] = handler
+
+    def register_route(self, method, path, handler):
+        """Register a raw HTTP handler. Rejects a route that would match the
+        same paths as one already registered."""
+        method, norm = _normalize_route(method, path)
+        pattern = compile_pattern(norm)
+        for existing in self.routes:
+            if existing["method"] == method and patterns_conflict(existing["pattern"], pattern):
+                raise ValueError(
+                    f"Route {method} {path!r} conflicts with the registered {existing['method']} {existing['path']!r}"
+                )
+        self.routes.append({"method": method, "path": norm, "pattern": pattern, "handler": handler})
+        self.routes.sort(key=lambda route: specificity(route["pattern"]), reverse=True)
+
+    def match_route(self, method, path):
+        """Return `(handler, path_params)` for the first route matching
+        `method` and `path`, or `None`."""
+        method = method.upper()
+        for route in self.routes:
+            if route["method"] != method:
+                continue
+            params = match_pattern(route["pattern"], path)
+            if params is not None:
+                return route["handler"], params
+        return None
+
+    def route_defs(self):
+        """Sorted `(method, path)` pairs with `{name}` tokens intact, for
+        `cordless deploy` to sync onto the API."""
+        return sorted((route["method"], route["path"]) for route in self.routes)
 
     def register_error_handler(self, handler):
         self._error_handler = handler

--- a/src/cordless/routes.py
+++ b/src/cordless/routes.py
@@ -1,0 +1,188 @@
+"""Raw HTTP route matching and response coercion for `@bot.route` handlers.
+
+These routes sit outside the Discord interaction flow. A request arrives on
+the same Lambda, skips signature verification, and the handler receives the
+raw event dict together with the bot instance.
+"""
+
+import base64
+import json
+import re
+
+_PARAM_NAME = re.compile(r"[A-Za-z0-9._]+")
+_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+
+_JSON_CONTENT_TYPE = "application/json"
+_TEXT_CONTENT_TYPE = "text/plain; charset=utf-8"
+_BINARY_CONTENT_TYPE = "application/octet-stream"
+
+
+def normalize_path(path):
+    """Return `path` with a leading slash, single slashes between segments,
+    and no trailing slash except for the root."""
+    segments = [s for s in path.split("/") if s]
+    return "/" + "/".join(segments)
+
+
+def normalize(method, path):
+    """Validate a route and return its canonical `(method, path)` pair.
+
+    Raises `ValueError` for an unknown method, a malformed `{name}` segment,
+    or the `POST /` route, which is reserved for Discord's interaction
+    endpoint.
+    """
+    method = method.upper()
+    if method not in _METHODS:
+        raise ValueError(f"Unknown HTTP method {method!r}: expected one of {', '.join(sorted(_METHODS))}")
+
+    norm = normalize_path(path)
+    segments = [s for s in norm.split("/") if s]
+    for index, segment in enumerate(segments):
+        if segment.startswith("{") and segment.endswith("}"):
+            name = segment[1:-1]
+            greedy = name.endswith("+")
+            if greedy:
+                name = name[:-1]
+                if index != len(segments) - 1:
+                    raise ValueError(f"Greedy parameter {segment!r} in {path!r} must be the final segment")
+            if not _PARAM_NAME.fullmatch(name):
+                raise ValueError(f"Invalid path parameter {segment!r} in {path!r}")
+        elif "{" in segment or "}" in segment:
+            raise ValueError(
+                f"Invalid path segment {segment!r} in {path!r}: a parameter must be a whole segment like {{id}}"
+            )
+
+    if (method, norm) == ("POST", "/"):
+        raise ValueError("POST / is reserved for Discord's interaction endpoint")
+    return method, norm
+
+
+def compile_pattern(norm_path):
+    """Turn a normalised path into a list of match segments, each a
+    `("lit", value)`, `("param", name)`, or `("greedy", name)` tuple."""
+    pattern = []
+    for segment in (s for s in norm_path.split("/") if s):
+        if segment.startswith("{") and segment.endswith("}"):
+            name = segment[1:-1]
+            if name.endswith("+"):
+                pattern.append(("greedy", name[:-1]))
+            else:
+                pattern.append(("param", name))
+        else:
+            pattern.append(("lit", segment))
+    return pattern
+
+
+def match_pattern(pattern, path):
+    """Return a `{name: value}` dict when `path` matches `pattern`, else
+    `None`. A greedy segment captures the rest of the path verbatim."""
+    parts = [p for p in path.split("/") if p]
+    params = {}
+    for index, (kind, value) in enumerate(pattern):
+        if kind == "greedy":
+            if index >= len(parts):
+                return None
+            params[value] = "/".join(parts[index:])
+            return params
+        if index >= len(parts):
+            return None
+        if kind == "lit":
+            if parts[index] != value:
+                return None
+        else:
+            params[value] = parts[index]
+    if len(parts) != len(pattern):
+        return None
+    return params
+
+
+def patterns_conflict(a, b):
+    """True when two patterns would match the same set of paths, so only one
+    can be registered. Parameter names are ignored; literal values are not."""
+    if len(a) != len(b):
+        return False
+    for (kind_a, value_a), (kind_b, value_b) in zip(a, b):
+        if kind_a != kind_b:
+            return False
+        if kind_a == "lit" and value_a != value_b:
+            return False
+    return True
+
+
+def specificity(pattern):
+    """Sort key placing more literal, longer, non-greedy patterns first, so
+    a static route always wins over one with a parameter in the same slot."""
+    literals = sum(1 for kind, _ in pattern if kind == "lit")
+    has_greedy = any(kind == "greedy" for kind, _ in pattern)
+    return (literals, len(pattern), not has_greedy)
+
+
+def request_method_path(event):
+    """Pull the HTTP method and path from a Lambda event.
+
+    Handles the API Gateway v2 shape (`requestContext.http`), the v1 shape
+    (`httpMethod` / `path`), and the local dev server. Returns
+    `(None, None)` for a bare interaction invoke that carries no HTTP
+    envelope.
+    """
+    request_context = event.get("requestContext") or {}
+    http = request_context.get("http") or {}
+    method = http.get("method") or event.get("httpMethod")
+    path = http.get("path") or event.get("rawPath") or event.get("path")
+    if method is None or path is None:
+        return None, None
+    return method.upper(), normalize_path(path)
+
+
+def build_response(returned):
+    """Coerce a route handler's return value into a Lambda proxy response.
+
+    Accepts a full proxy dict (passed through unchanged), a status int, a
+    string, a bytes body, a JSON serialisable dict or list, or a
+    `(status, body)` or `(status, body, headers)` tuple.
+    """
+    if isinstance(returned, dict) and "statusCode" in returned:
+        return returned
+
+    headers = {}
+    if isinstance(returned, tuple):
+        if len(returned) == 2:
+            status, body = returned
+        elif len(returned) == 3:
+            status, body, headers = returned
+        else:
+            raise ValueError(
+                f"A route handler tuple must be (status, body) or (status, body, headers), got {len(returned)} items"
+            )
+    elif isinstance(returned, bool):
+        raise ValueError(f"A route handler cannot return a bool ({returned!r}); return an int, str, dict, or tuple")
+    elif isinstance(returned, int):
+        status, body = returned, None
+    else:
+        status, body = 200, returned
+
+    return _finish(status, body, dict(headers or {}))
+
+
+def _finish(status, body, headers):
+    is_base64 = False
+    if body is None:
+        out_body = ""
+    elif isinstance(body, (bytes, bytearray)):
+        out_body = base64.b64encode(bytes(body)).decode()
+        is_base64 = True
+        headers.setdefault("Content-Type", _BINARY_CONTENT_TYPE)
+    elif isinstance(body, str):
+        out_body = body
+        headers.setdefault("Content-Type", _TEXT_CONTENT_TYPE)
+    elif isinstance(body, (dict, list)):
+        out_body = json.dumps(body)
+        headers.setdefault("Content-Type", _JSON_CONTENT_TYPE)
+    else:
+        out_body = str(body)
+        headers.setdefault("Content-Type", _TEXT_CONTENT_TYPE)
+
+    response = {"statusCode": status, "headers": headers, "body": out_body}
+    if is_base64:
+        response["isBase64Encoded"] = True
+    return response

--- a/src/cordless/testing.py
+++ b/src/cordless/testing.py
@@ -10,10 +10,15 @@ Import the module and use it as a namespace, e.g.:
 """
 
 import base64
+import collections
 import json
+import urllib.parse
 
 from ._multipart import parse_multipart_payload
 from .context import Context
+from .routes import build_response, normalize_path
+
+RouteResponse = collections.namedtuple("RouteResponse", ["status", "body", "headers"])
 
 _APPLICATION_COMMAND = 2
 _MESSAGE_COMPONENT = 3
@@ -395,3 +400,42 @@ async def invoke(bot, interaction_or_name, options=None, *, worker_mode=False, *
     if raw.get("isBase64Encoded"):
         return parse_multipart_payload(base64.b64decode(raw["body"])), ctx
     return json.loads(raw["body"]), ctx
+
+
+async def invoke_route(bot, method, path, *, body="", headers=None, query=None):
+    """Dispatch a `@bot.route` handler and return a
+    `RouteResponse(status, body, headers)`.
+
+    The handler runs against the bot's real router, the same match a
+    deployed Lambda makes, with no HTTP layer or signature check. `body` is
+    decoded from JSON when the response content type is JSON, otherwise
+    returned as text. An unmatched route yields a 404, matching the
+    deployed behaviour.
+    """
+    method = method.upper()
+    norm = normalize_path(path)
+    match = bot.router.match_route(method, norm)
+    if match is None:
+        return RouteResponse(404, {"error": f"no route for {method} {norm}"}, {})
+
+    handler, params = match
+    query = dict(query or {})
+    event = {
+        "body": body,
+        "headers": dict(headers or {}),
+        "rawPath": norm,
+        "rawQueryString": urllib.parse.urlencode(query),
+        "queryStringParameters": query or None,
+        "pathParameters": params,
+        "requestContext": {"http": {"method": method, "path": norm}},
+        "isBase64Encoded": False,
+    }
+    result = build_response(await handler(event, bot))
+    out_headers = result.get("headers", {})
+    raw = result.get("body", "")
+    if result.get("isBase64Encoded"):
+        decoded = base64.b64decode(raw)
+    else:
+        content_type = next((v for k, v in out_headers.items() if k.lower() == "content-type"), "")
+        decoded = json.loads(raw) if raw and "application/json" in content_type else raw
+    return RouteResponse(result["statusCode"], decoded, out_headers)

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -588,6 +588,21 @@ def test_health_check_reports_missing_api_route(aws_clients, tmp_path):
     assert label_map["API routes"] == (False, "missing: POST /b")
 
 
+def test_health_check_lists_routes_on_function_url(aws_clients, tmp_path):
+    iam, lam, apigw, events = aws_clients["iam"], aws_clients["lam"], aws_clients["apigw"], aws_clients["events"]
+    role_arn = _make_role(iam)
+    _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+    _ensure_function_url(lam, "my-fn")
+
+    routes = [("GET", "/healthz"), ("POST", "/hook/{id}")]
+    checks = _health_check(lam, apigw, events, None, "my-fn", None, "function_url", None, False, False, None, routes)
+
+    label_map = {label: (ok, detail) for ok, label, detail in checks}
+    assert label_map["HTTP routes"][0] is True
+    assert "GET /healthz" in label_map["HTTP routes"][1]
+    assert "POST /hook/{id}" in label_map["HTTP routes"][1]
+
+
 def test_health_check_reports_ratelimit_table_status(aws_clients, tmp_path):
     iam, lam, apigw, events = aws_clients["iam"], aws_clients["lam"], aws_clients["apigw"], aws_clients["events"]
     dynamodb = boto3.client("dynamodb", region_name=REGION)
@@ -812,21 +827,34 @@ def test_deploy_keeps_existing_function_url_when_unspecified(deploy_patches, mon
 
 
 @mock_aws
-def test_deploy_defaults_to_api_gateway_when_routes_present(deploy_patches, monkeypatch):
+def test_deploy_keeps_function_url_default_when_routes_present(deploy_patches, monkeypatch):
+    """Adding a bot.route no longer forces api_gateway: an unset endpoint
+    stays on the default Function URL, where cordless does the path matching."""
     iam = boto3.client("iam", region_name=REGION)
     monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
     deploy(**_base_deploy_kwargs(deploy_patches, routes=[("POST", "/stripe/webhook")]))
+    lam = boto3.client("lambda", region_name=REGION)
+    assert lam.get_function_url_config(FunctionName="my-bot")["FunctionUrl"]
     apigw = boto3.client("apigatewayv2", region_name=REGION)
-    api_id = next(a["ApiId"] for a in apigw.get_apis()["Items"] if a["Name"] == "my-bot-api")
-    assert "POST /stripe/webhook" in {r["RouteKey"] for r in _list_all_routes(apigw, api_id)}
+    assert not any(a["Name"] == "my-bot-api" for a in apigw.get_apis()["Items"])
 
 
 @mock_aws
-def test_deploy_rejects_routes_on_function_url(deploy_patches, monkeypatch):
+def test_deploy_allows_routes_on_function_url(deploy_patches, monkeypatch):
     iam = boto3.client("iam", region_name=REGION)
     monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
-    with pytest.raises(SystemExit, match="api_gateway"):
-        deploy(**_base_deploy_kwargs(deploy_patches, endpoint="function_url", routes=[("POST", "/x")]))
+    url = deploy(**_base_deploy_kwargs(deploy_patches, endpoint="function_url", routes=[("POST", "/x")]))
+    assert ".lambda-url." in url
+
+
+@mock_aws
+def test_deploy_syncs_routes_on_explicit_api_gateway(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches, endpoint="api_gateway", routes=[("POST", "/stripe/webhook")]))
+    apigw = boto3.client("apigatewayv2", region_name=REGION)
+    api_id = next(a["ApiId"] for a in apigw.get_apis()["Items"] if a["Name"] == "my-bot-api")
+    assert "POST /stripe/webhook" in {r["RouteKey"] for r in _list_all_routes(apigw, api_id)}
 
 
 @mock_aws

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -240,6 +240,35 @@ def test_ensure_api_gateway_syncs_bot_routes(aws_clients, tmp_path):
     assert {r["RouteKey"] for r in _list_all_routes(apigw, api_id)} == {"POST /", "POST /stripe/webhook"}
 
 
+def test_ensure_api_gateway_routes_none_leaves_synced_routes_alone(aws_clients, tmp_path):
+    iam, lam, apigw = aws_clients["iam"], aws_clients["lam"], aws_clients["apigw"]
+    role_arn = _make_role(iam)
+    fn_arn = _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+
+    _ensure_api_gateway(
+        apigw, lam, "my-fn", fn_arn, REGION, ACCOUNT_ID, routes=[("POST", "/stripe"), ("GET", "/gh/{repo}/hook")]
+    )
+    api_id = next(a["ApiId"] for a in apigw.get_apis()["Items"] if a["Name"] == "my-fn-api")
+
+    # routes=None (the bot could not be loaded) must not prune anything
+    _ensure_api_gateway(apigw, lam, "my-fn", fn_arn, REGION, ACCOUNT_ID, routes=None)
+    assert {r["RouteKey"] for r in _list_all_routes(apigw, api_id)} == {
+        "POST /",
+        "POST /stripe",
+        "GET /gh/{repo}/hook",
+    }
+
+
+def test_ensure_api_gateway_rewrites_greedy_param_to_proxy(aws_clients, tmp_path):
+    iam, lam, apigw = aws_clients["iam"], aws_clients["lam"], aws_clients["apigw"]
+    role_arn = _make_role(iam)
+    fn_arn = _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+
+    _ensure_api_gateway(apigw, lam, "my-fn", fn_arn, REGION, ACCOUNT_ID, routes=[("GET", "/files/{rest+}")])
+    api_id = next(a["ApiId"] for a in apigw.get_apis()["Items"] if a["Name"] == "my-fn-api")
+    assert {r["RouteKey"] for r in _list_all_routes(apigw, api_id)} == {"POST /", "GET /files/{proxy+}"}
+
+
 def test_ensure_api_gateway_reuses_one_integration(aws_clients, tmp_path):
     iam, lam, apigw = aws_clients["iam"], aws_clients["lam"], aws_clients["apigw"]
     role_arn = _make_role(iam)

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -13,6 +13,7 @@ from cordless.deploy import (
     _ensure_function_url,
     _function_exists,
     _health_check,
+    _list_all_routes,
     _publish_cordless_layer,
     _remove_keepwarm,
     _wire_crons,
@@ -209,6 +210,44 @@ def test_ensure_api_gateway_is_idempotent(aws_clients, tmp_path):
     url2 = _ensure_api_gateway(apigw, lam, "my-fn", fn_arn, REGION, ACCOUNT_ID)
     assert url1 == url2
     assert len(apigw.get_apis()["Items"]) == 1
+
+
+def test_ensure_api_gateway_always_has_discord_route(aws_clients, tmp_path):
+    iam, lam, apigw = aws_clients["iam"], aws_clients["lam"], aws_clients["apigw"]
+    role_arn = _make_role(iam)
+    fn_arn = _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+    _ensure_api_gateway(apigw, lam, "my-fn", fn_arn, REGION, ACCOUNT_ID)
+    api_id = next(a["ApiId"] for a in apigw.get_apis()["Items"] if a["Name"] == "my-fn-api")
+    assert {r["RouteKey"] for r in _list_all_routes(apigw, api_id)} == {"POST /"}
+
+
+def test_ensure_api_gateway_syncs_bot_routes(aws_clients, tmp_path):
+    iam, lam, apigw = aws_clients["iam"], aws_clients["lam"], aws_clients["apigw"]
+    role_arn = _make_role(iam)
+    fn_arn = _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+
+    routes = [("POST", "/stripe/webhook"), ("GET", "/gh/{repo}/hook")]
+    _ensure_api_gateway(apigw, lam, "my-fn", fn_arn, REGION, ACCOUNT_ID, routes=routes)
+    api_id = next(a["ApiId"] for a in apigw.get_apis()["Items"] if a["Name"] == "my-fn-api")
+    assert {r["RouteKey"] for r in _list_all_routes(apigw, api_id)} == {
+        "POST /",
+        "POST /stripe/webhook",
+        "GET /gh/{repo}/hook",
+    }
+
+    # a route dropped from the bot is pruned on the next deploy; POST / stays
+    _ensure_api_gateway(apigw, lam, "my-fn", fn_arn, REGION, ACCOUNT_ID, routes=[("POST", "/stripe/webhook")])
+    assert {r["RouteKey"] for r in _list_all_routes(apigw, api_id)} == {"POST /", "POST /stripe/webhook"}
+
+
+def test_ensure_api_gateway_reuses_one_integration(aws_clients, tmp_path):
+    iam, lam, apigw = aws_clients["iam"], aws_clients["lam"], aws_clients["apigw"]
+    role_arn = _make_role(iam)
+    fn_arn = _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+    _ensure_api_gateway(apigw, lam, "my-fn", fn_arn, REGION, ACCOUNT_ID, routes=[("GET", "/a")])
+    _ensure_api_gateway(apigw, lam, "my-fn", fn_arn, REGION, ACCOUNT_ID, routes=[("GET", "/a"), ("GET", "/b")])
+    api_id = next(a["ApiId"] for a in apigw.get_apis()["Items"] if a["Name"] == "my-fn-api")
+    assert len(apigw.get_integrations(ApiId=api_id)["Items"]) == 1
 
 
 def test_ensure_function_url_creates_url(aws_clients, tmp_path):
@@ -536,6 +575,19 @@ def test_health_check_reports_api_gateway_endpoint(aws_clients, tmp_path):
     assert label_map["API Gateway"][0] is True
 
 
+def test_health_check_reports_missing_api_route(aws_clients, tmp_path):
+    iam, lam, apigw, events = aws_clients["iam"], aws_clients["lam"], aws_clients["apigw"], aws_clients["events"]
+    role_arn = _make_role(iam)
+    fn_arn = _make_function(lam, "my-fn", role_arn, _minimal_zip(tmp_path))
+    _ensure_api_gateway(apigw, lam, "my-fn", fn_arn, REGION, ACCOUNT_ID, routes=[("GET", "/a")])
+
+    routes = [("GET", "/a"), ("POST", "/b")]
+    checks = _health_check(lam, apigw, events, None, "my-fn", None, "api_gateway", None, False, False, None, routes)
+
+    label_map = {label: (ok, detail) for ok, label, detail in checks}
+    assert label_map["API routes"] == (False, "missing: POST /b")
+
+
 def test_health_check_reports_ratelimit_table_status(aws_clients, tmp_path):
     iam, lam, apigw, events = aws_clients["iam"], aws_clients["lam"], aws_clients["apigw"], aws_clients["events"]
     dynamodb = boto3.client("dynamodb", region_name=REGION)
@@ -757,6 +809,24 @@ def test_deploy_keeps_existing_function_url_when_unspecified(deploy_patches, mon
     lam = boto3.client("lambda", region_name=REGION)
     config = lam.get_function_url_config(FunctionName="my-bot")
     assert config["FunctionUrl"]
+
+
+@mock_aws
+def test_deploy_defaults_to_api_gateway_when_routes_present(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    deploy(**_base_deploy_kwargs(deploy_patches, routes=[("POST", "/stripe/webhook")]))
+    apigw = boto3.client("apigatewayv2", region_name=REGION)
+    api_id = next(a["ApiId"] for a in apigw.get_apis()["Items"] if a["Name"] == "my-bot-api")
+    assert "POST /stripe/webhook" in {r["RouteKey"] for r in _list_all_routes(apigw, api_id)}
+
+
+@mock_aws
+def test_deploy_rejects_routes_on_function_url(deploy_patches, monkeypatch):
+    iam = boto3.client("iam", region_name=REGION)
+    monkeypatch.setattr(cordless.deploy, "_LAMBDA_BASIC_EXECUTION_POLICY", _seed_lambda_execution_policy(iam))
+    with pytest.raises(SystemExit, match="api_gateway"):
+        deploy(**_base_deploy_kwargs(deploy_patches, endpoint="function_url", routes=[("POST", "/x")]))
 
 
 @mock_aws

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -226,6 +226,59 @@ def test_dev_unmatched_route_is_404(route_dev_server):
         assert exc.code == 404
 
 
+def _serve_route_bot(tmp_path, module_src):
+    (tmp_path / "rbot.py").write_text(module_src)
+    sys.path.insert(0, str(tmp_path))
+    reloader = Reloader("rbot:bot", str(tmp_path))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _make_handler(reloader))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    def cleanup():
+        server.shutdown()
+        server.server_close()
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("rbot", None)
+
+    return f"http://127.0.0.1:{server.server_address[1]}", cleanup
+
+
+def test_dev_route_gets_non_utf8_body_as_base64(tmp_path):
+    url, cleanup = _serve_route_bot(
+        tmp_path,
+        "import base64\n"
+        "from cordless import Cordless\n"
+        "bot = Cordless()\n"
+        "@bot.route('POST', '/raw')\n"
+        "async def raw(event, bot):\n"
+        "    assert event['isBase64Encoded'] is True\n"
+        "    return base64.b64decode(event['body']).hex()\n",
+    )
+    try:
+        req = urllib.request.Request(f"{url}/raw", data=b"\x80\x81\x82", method="POST")
+        with urllib.request.urlopen(req) as resp:
+            assert resp.read() == b"808182"
+    finally:
+        cleanup()
+
+
+def test_dev_route_returning_proxy_dict_with_bytes_body(tmp_path):
+    url, cleanup = _serve_route_bot(
+        tmp_path,
+        "from cordless import Cordless\n"
+        "bot = Cordless()\n"
+        "@bot.route('GET', '/bin')\n"
+        "async def binroute(event, bot):\n"
+        "    return {'statusCode': 200, 'body': b'raw-bytes'}\n",
+    )
+    try:
+        with urllib.request.urlopen(f"{url}/bin") as resp:
+            assert resp.status == 200
+            assert resp.read() == b"raw-bytes"
+    finally:
+        cleanup()
+
+
 def test_post_interaction_with_files_round_trips_raw_bytes(bot_project):
     """isBase64Encoded responses (multipart file attachments) must be decoded
     back to raw bytes before hitting the socket, same as real API Gateway."""

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -177,6 +177,55 @@ def test_get_health_check(dev_server):
         assert resp.status == 200
 
 
+@pytest.fixture
+def route_bot_project(tmp_path):
+    (tmp_path / "mybot.py").write_text(
+        "import json\n"
+        "from cordless import Cordless\n"
+        "bot = Cordless()\n"
+        "@bot.route('POST', '/gh/{repo}/hook')\n"
+        "async def hook(event, bot):\n"
+        "    return {'repo': event['pathParameters']['repo'], 'body': json.loads(event['body'])}\n"
+        "@bot.route('GET', '/healthz')\n"
+        "async def healthz(event, bot):\n"
+        "    return 'ok'\n"
+    )
+    sys.path.insert(0, str(tmp_path))
+    yield tmp_path
+    sys.path.remove(str(tmp_path))
+    sys.modules.pop("mybot", None)
+
+
+@pytest.fixture
+def route_dev_server(route_bot_project):
+    reloader = Reloader("mybot:bot", str(route_bot_project))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _make_handler(reloader))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_address[1]}"
+    server.shutdown()
+    server.server_close()
+
+
+def test_dev_serves_post_route_with_path_param(route_dev_server):
+    req = urllib.request.Request(f"{route_dev_server}/gh/cordless/hook", data=b'{"ref": "main"}', method="POST")
+    with urllib.request.urlopen(req) as resp:
+        assert json.loads(resp.read()) == {"repo": "cordless", "body": {"ref": "main"}}
+
+
+def test_dev_serves_get_route(route_dev_server):
+    with urllib.request.urlopen(f"{route_dev_server}/healthz") as resp:
+        assert resp.read() == b"ok"
+
+
+def test_dev_unmatched_route_is_404(route_dev_server):
+    try:
+        urllib.request.urlopen(f"{route_dev_server}/nope")
+        assert False, "expected 404"
+    except urllib.error.HTTPError as exc:
+        assert exc.code == 404
+
+
 def test_post_interaction_with_files_round_trips_raw_bytes(bot_project):
     """isBase64Encoded responses (multipart file attachments) must be decoded
     back to raw bytes before hitting the socket, same as real API Gateway."""

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -263,6 +263,19 @@ def test_run_reports_undeployed_function_as_warn_not_fail():
     assert ok is False
 
 
+def test_run_threads_routes_into_deployed_function_check():
+    with mock_aws(), patch("cordless.doctor.check_deployed_function", return_value=[]) as cdf:
+        run(
+            function_name="my-fn",
+            role_name=None,
+            region=REGION,
+            local_env={"DISCORD_PUBLIC_KEY": "a" * 64},
+            routes=[("GET", "/healthz")],
+        )
+
+    assert cdf.call_args.args[-1] == [("GET", "/healthz")]
+
+
 def test_run_ok_false_when_public_key_missing():
     with mock_aws():
         sections, ok = run(function_name=None, role_name=None, region=REGION, local_env={})

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,7 +1,8 @@
+import json
 from unittest.mock import patch
 
 import pytest
-from conftest import FakeDiscordResponse
+from conftest import FakeDiscordResponse, make_http_error
 
 from cordless.app import Cordless, choice, option
 from cordless.register import sync_commands
@@ -376,6 +377,48 @@ def test_bot_sync_commands_skips_guild_calls_when_none_registered():
         bot.sync_commands(bot_token="bot-token")
 
     mock_sync.assert_called_once()
+
+
+def test_sync_commands_error_names_the_command_and_option():
+    commands = [
+        {
+            "name": "buy",
+            "description": "Buy an item",
+            "type": 1,
+            "options": [{"name": "qty", "description": "", "type": 4}],
+        }
+    ]
+    form_error = json.dumps(
+        {
+            "message": "Invalid Form Body",
+            "code": 50035,
+            "errors": {
+                "0": {
+                    "options": {
+                        "0": {"description": {"_errors": [{"message": "Must be between 1 and 100 in length."}]}}
+                    }
+                }
+            },
+        }
+    ).encode()
+    responses = [FakeDiscordResponse({"id": "app-id"}), make_http_error(400, body=form_error)]
+
+    with patch("cordless.register.urllib.request.urlopen", side_effect=responses):
+        with pytest.raises(RuntimeError) as exc:
+            sync_commands(commands, bot_token="bot-token")
+
+    message = str(exc.value)
+    assert "command 'buy'" in message
+    assert "option 'qty'" in message
+    assert "Must be between 1 and 100 in length." in message
+
+
+def test_sync_commands_error_falls_back_to_raw_body():
+    responses = [FakeDiscordResponse({"id": "app-id"}), make_http_error(401, body=b"Unauthorized")]
+
+    with patch("cordless.register.urllib.request.urlopen", side_effect=responses):
+        with pytest.raises(RuntimeError, match="Unauthorized"):
+            sync_commands([], bot_token="bot-token")
 
 
 def _basic(client_id, client_secret):

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -447,6 +447,88 @@ def test_registering_subcommand_under_existing_command_raises():
             pass
 
 
+def test_empty_command_description_raises_naming_the_command():
+    bot = Cordless()
+
+    with pytest.raises(ValueError, match="Command 'buy': description must be 1 to 100"):
+
+        @bot.command("buy", description="")
+        async def buy(ctx):
+            pass
+
+
+def test_overlong_command_description_raises():
+    bot = Cordless()
+
+    with pytest.raises(ValueError, match="Command 'buy': description"):
+
+        @bot.command("buy", description="x" * 101)
+        async def buy(ctx):
+            pass
+
+
+def test_empty_option_description_raises_naming_command_and_option():
+    bot = Cordless()
+
+    with pytest.raises(ValueError, match="Command 'buy' option 'qty': description"):
+
+        @bot.command("buy", description="Buy", options=[{"name": "qty", "description": "", "type": 4}])
+        async def buy(ctx):
+            pass
+
+
+def test_uppercase_option_name_raises():
+    bot = Cordless()
+
+    with pytest.raises(ValueError, match="Command 'buy': invalid option name 'Qty'"):
+
+        @bot.command("buy", description="Buy", options=[{"name": "Qty", "description": "How many", "type": 4}])
+        async def buy(ctx):
+            pass
+
+
+def test_more_than_25_options_raises():
+    bot = Cordless()
+    options = [{"name": f"o{i}", "description": "x", "type": 3} for i in range(26)]
+
+    with pytest.raises(ValueError, match="Command 'buy' has 26 options"):
+
+        @bot.command("buy", description="Buy", options=options)
+        async def buy(ctx):
+            pass
+
+
+def test_more_than_25_choices_raises():
+    bot = Cordless()
+    opt = {"name": "n", "description": "x", "type": 4, "choices": [{"name": str(i), "value": i} for i in range(26)]}
+
+    with pytest.raises(ValueError, match="option 'n' has 26 choices"):
+
+        @bot.command("pick", description="Pick", options=[opt])
+        async def pick(ctx):
+            pass
+
+
+def test_group_description_length_validated():
+    bot = Cordless()
+
+    with pytest.raises(ValueError, match="Command 'shop/admin/ban' group: description"):
+
+        @bot.command("shop/admin/ban", description="Ban", group_description="x" * 101)
+        async def ban(ctx):
+            pass
+
+
+def test_inferred_options_pass_validation():
+    bot = Cordless()
+
+    @bot.command("buy", description="Buy an item")
+    async def buy(ctx, item: str, qty: int = 1):
+        pass
+
+    assert "buy" in bot.router.commands
+
+
 def test_subcommand_permissions_propagate_to_parent():
     bot = Cordless()
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,359 @@
+import json
+from asyncio import run
+
+import pytest
+
+from cordless import Cog
+from cordless.app import Cordless
+from cordless.errors import CordlessError
+from cordless.routes import (
+    build_response,
+    compile_pattern,
+    match_pattern,
+    normalize,
+    request_method_path,
+)
+from cordless.testing import invoke_route
+
+
+def _event(method, path, *, body="", headers=None, query=None):
+    return {
+        "body": body,
+        "headers": headers or {},
+        "rawPath": path,
+        "rawQueryString": "",
+        "queryStringParameters": query,
+        "requestContext": {"http": {"method": method, "path": path}},
+        "isBase64Encoded": False,
+    }
+
+
+# --- normalize ---
+
+
+def test_normalize_adds_leading_slash_and_trims_trailing():
+    assert normalize("get", "healthz/") == ("GET", "/healthz")
+
+
+def test_normalize_collapses_repeated_slashes():
+    assert normalize("GET", "//a///b/") == ("GET", "/a/b")
+
+
+def test_normalize_rejects_unknown_method():
+    with pytest.raises(ValueError, match="Unknown HTTP method"):
+        normalize("FETCH", "/x")
+
+
+def test_normalize_rejects_post_root():
+    with pytest.raises(ValueError, match="reserved for Discord"):
+        normalize("POST", "/")
+
+
+def test_normalize_rejects_partial_parameter_segment():
+    with pytest.raises(ValueError, match="whole segment"):
+        normalize("GET", "/users/u{id}")
+
+
+def test_normalize_rejects_greedy_before_final_segment():
+    with pytest.raises(ValueError, match="final segment"):
+        normalize("GET", "/files/{rest+}/meta")
+
+
+# --- pattern matching ---
+
+
+def test_match_pattern_exact():
+    assert match_pattern(compile_pattern("/a/b"), "/a/b") == {}
+    assert match_pattern(compile_pattern("/a/b"), "/a/c") is None
+
+
+def test_match_pattern_captures_param():
+    assert match_pattern(compile_pattern("/gh/{repo}/hook"), "/gh/cordless/hook") == {"repo": "cordless"}
+
+
+def test_match_pattern_length_mismatch():
+    assert match_pattern(compile_pattern("/a/{x}"), "/a/b/c") is None
+    assert match_pattern(compile_pattern("/a/{x}"), "/a") is None
+
+
+def test_match_pattern_greedy_captures_remainder():
+    assert match_pattern(compile_pattern("/files/{rest+}"), "/files/a/b/c") == {"rest": "a/b/c"}
+    assert match_pattern(compile_pattern("/files/{rest+}"), "/files") is None
+
+
+def test_root_pattern_matches_root():
+    assert match_pattern(compile_pattern("/"), "/") == {}
+
+
+# --- request_method_path ---
+
+
+def test_request_method_path_v2_shape():
+    assert request_method_path({"requestContext": {"http": {"method": "post", "path": "/x/"}}}) == ("POST", "/x")
+
+
+def test_request_method_path_v1_shape():
+    assert request_method_path({"httpMethod": "GET", "path": "/x"}) == ("GET", "/x")
+
+
+def test_request_method_path_bare_interaction():
+    assert request_method_path({"body": "{}"}) == (None, None)
+
+
+# --- build_response ---
+
+
+def test_build_response_passes_through_proxy_dict():
+    proxy = {"statusCode": 201, "headers": {}, "body": "ok"}
+    assert build_response(proxy) is proxy
+
+
+def test_build_response_string():
+    r = build_response("hello")
+    assert r["statusCode"] == 200
+    assert r["body"] == "hello"
+    assert r["headers"]["Content-Type"].startswith("text/plain")
+
+
+def test_build_response_dict_is_json():
+    r = build_response({"ok": True})
+    assert r["headers"]["Content-Type"] == "application/json"
+    assert json.loads(r["body"]) == {"ok": True}
+
+
+def test_build_response_bare_int_is_status():
+    r = build_response(204)
+    assert r["statusCode"] == 204
+    assert r["body"] == ""
+
+
+def test_build_response_none_is_empty_200():
+    r = build_response(None)
+    assert r["statusCode"] == 200
+    assert r["body"] == ""
+
+
+def test_build_response_status_body_tuple():
+    r = build_response((418, "teapot"))
+    assert r["statusCode"] == 418
+    assert r["body"] == "teapot"
+
+
+def test_build_response_status_body_headers_tuple():
+    r = build_response((302, "", {"Location": "https://example.com"}))
+    assert r["statusCode"] == 302
+    assert r["headers"]["Location"] == "https://example.com"
+
+
+def test_build_response_bytes_is_base64():
+    r = build_response(b"\x00\x01\x02")
+    assert r["isBase64Encoded"] is True
+    assert r["headers"]["Content-Type"] == "application/octet-stream"
+
+
+def test_build_response_rejects_bool():
+    with pytest.raises(ValueError, match="cannot return a bool"):
+        build_response(True)
+
+
+def test_build_response_rejects_wrong_tuple_length():
+    with pytest.raises(ValueError, match="must be"):
+        build_response((1, 2, 3, 4))
+
+
+# --- registration ---
+
+
+def test_route_registration_conflict_raises():
+    bot = Cordless()
+
+    @bot.route("GET", "/gh/{repo}/hook")
+    async def a(event, bot):
+        return "a"
+
+    with pytest.raises(ValueError, match="conflicts with"):
+
+        @bot.route("GET", "/gh/{name}/hook")
+        async def b(event, bot):
+            return "b"
+
+
+def test_route_registration_rejects_post_root():
+    bot = Cordless()
+    with pytest.raises(ValueError, match="reserved for Discord"):
+
+        @bot.route("POST", "/")
+        async def a(event, bot):
+            return "a"
+
+
+def test_route_defs_sorted_with_tokens_intact():
+    bot = Cordless()
+
+    @bot.route("POST", "/stripe/webhook")
+    async def a(event, bot):
+        return ""
+
+    @bot.route("GET", "/gh/{repo}/hook")
+    async def b(event, bot):
+        return ""
+
+    assert bot.router.route_defs() == [("GET", "/gh/{repo}/hook"), ("POST", "/stripe/webhook")]
+
+
+# --- dispatch through handle() ---
+
+
+def test_handle_dispatches_route():
+    bot = Cordless()
+
+    @bot.route("POST", "/stripe/webhook")
+    async def hook(event, received_bot):
+        assert received_bot is bot
+        return {"got": json.loads(event["body"])["id"]}
+
+    result = bot.handle(_event("POST", "/stripe/webhook", body='{"id": "evt_1"}'))
+    assert result["statusCode"] == 200
+    assert json.loads(result["body"]) == {"got": "evt_1"}
+
+
+def test_handle_passes_path_params():
+    bot = Cordless()
+    seen = {}
+
+    @bot.route("GET", "/gh/{repo}/hook")
+    async def hook(event, bot):
+        seen.update(event["pathParameters"])
+        return 204
+
+    result = bot.handle(_event("GET", "/gh/cordless/hook"))
+    assert result["statusCode"] == 204
+    assert seen == {"repo": "cordless"}
+
+
+def test_handle_unmatched_route_is_404():
+    bot = Cordless()
+
+    @bot.route("GET", "/healthz")
+    async def health(event, bot):
+        return "ok"
+
+    result = bot.handle(_event("GET", "/nope"))
+    assert result["statusCode"] == 404
+
+
+def test_handle_still_routes_discord_interaction_on_post_root():
+    bot = Cordless()
+
+    @bot.route("GET", "/healthz")
+    async def health(event, bot):
+        return "ok"
+
+    @bot.command("ping")
+    async def ping(ctx):
+        return await ctx.send("pong")
+
+    result = bot.handle({"body": json.dumps({"type": 2, "data": {"name": "ping"}})})
+    assert json.loads(result["body"])["data"]["content"] == "pong"
+
+
+def test_handle_route_skips_signature_verification():
+    bot = Cordless(public_key="0" * 64)
+
+    @bot.route("POST", "/stripe/webhook")
+    async def hook(event, bot):
+        return "ok"
+
+    result = bot.handle(_event("POST", "/stripe/webhook", body="{}"))
+    assert result["statusCode"] == 200
+    assert result["body"] == "ok"
+
+
+def test_handle_route_cordless_error_is_400():
+    bot = Cordless()
+
+    @bot.route("GET", "/boom")
+    async def boom(event, bot):
+        raise CordlessError("nope")
+
+    result = bot.handle(_event("GET", "/boom"))
+    assert result["statusCode"] == 400
+    assert json.loads(result["body"])["error"] == "nope"
+
+
+def test_handle_route_unexpected_error_is_500():
+    bot = Cordless()
+
+    @bot.route("GET", "/boom")
+    async def boom(event, bot):
+        raise RuntimeError("kaboom")
+
+    result = bot.handle(_event("GET", "/boom"))
+    assert result["statusCode"] == 500
+
+
+def test_bot_without_routes_is_untouched():
+    bot = Cordless()
+
+    @bot.command("ping")
+    async def ping(ctx):
+        return await ctx.send("pong")
+
+    result = bot.handle({"body": json.dumps({"type": 2, "data": {"name": "ping"}})})
+    assert json.loads(result["body"])["data"]["content"] == "pong"
+
+
+def test_static_route_beats_parameter_route():
+    bot = Cordless()
+
+    @bot.route("GET", "/u/{name}")
+    async def dynamic(event, bot):
+        return "dynamic"
+
+    @bot.route("GET", "/u/me")
+    async def static(event, bot):
+        return "static"
+
+    assert bot.handle(_event("GET", "/u/me"))["body"] == "static"
+    assert bot.handle(_event("GET", "/u/alice"))["body"] == "dynamic"
+
+
+# --- Cog ---
+
+
+def test_cog_route_registers():
+    bot = Cordless()
+    cog = Cog()
+
+    @cog.route("GET", "/healthz")
+    async def health(event, bot):
+        return "ok"
+
+    bot.add_cog(cog)
+    assert bot.handle(_event("GET", "/healthz"))["body"] == "ok"
+
+
+# --- testing.invoke_route ---
+
+
+def test_invoke_route_helper():
+    bot = Cordless()
+
+    @bot.route("POST", "/gh/{repo}/hook")
+    async def hook(event, bot):
+        return {"repo": event["pathParameters"]["repo"], "body": json.loads(event["body"])}
+
+    resp = run(invoke_route(bot, "POST", "/gh/cordless/hook", body='{"ref": "main"}'))
+    assert resp.status == 200
+    assert resp.body == {"repo": "cordless", "body": {"ref": "main"}}
+
+
+def test_invoke_route_helper_unmatched():
+    bot = Cordless()
+
+    @bot.route("GET", "/healthz")
+    async def health(event, bot):
+        return "ok"
+
+    resp = run(invoke_route(bot, "GET", "/missing"))
+    assert resp.status == 404

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -257,6 +257,33 @@ def test_handle_still_routes_discord_interaction_on_post_root():
     assert json.loads(result["body"])["data"]["content"] == "pong"
 
 
+def test_handle_routes_discord_interaction_on_non_root_post_path():
+    bot = Cordless()
+
+    @bot.route("GET", "/healthz")
+    async def health(event, bot):
+        return "ok"
+
+    @bot.command("ping")
+    async def ping(ctx):
+        return await ctx.send("pong")
+
+    # an interaction endpoint URL with a path segment must still reach dispatch
+    result = bot.handle(_event("POST", "/discord/interactions", body=json.dumps({"type": 2, "data": {"name": "ping"}})))
+    assert json.loads(result["body"])["data"]["content"] == "pong"
+
+
+def test_handle_unmatched_non_post_is_still_404():
+    bot = Cordless()
+
+    @bot.route("POST", "/stripe")
+    async def hook(event, bot):
+        return "ok"
+
+    result = bot.handle(_event("GET", "/nope"))
+    assert result["statusCode"] == 404
+
+
 def test_handle_route_skips_signature_verification():
     bot = Cordless(public_key="0" * 64)
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -413,7 +413,11 @@ def test_autocomplete_nests_subcommand_path():
 def test_invoke_dispatches_autocomplete_and_filters_string_choices():
     bot = _bot()
 
-    @bot.command("shop", description="shop", options=[{"name": "item", "type": 3, "autocomplete": True}])
+    @bot.command(
+        "shop",
+        description="shop",
+        options=[{"name": "item", "type": 3, "description": "item to buy", "autocomplete": True}],
+    )
     async def shop(ctx, item: str):
         await ctx.send("bought")
 
@@ -430,7 +434,11 @@ def test_invoke_dispatches_autocomplete_and_filters_string_choices():
 def test_invoke_dispatches_autocomplete_with_dict_choices_unfiltered():
     bot = _bot()
 
-    @bot.command("shop", description="shop", options=[{"name": "item", "type": 3, "autocomplete": True}])
+    @bot.command(
+        "shop",
+        description="shop",
+        options=[{"name": "item", "type": 3, "description": "item to buy", "autocomplete": True}],
+    )
     async def shop(ctx, item: str):
         await ctx.send("bought")
 
@@ -445,7 +453,11 @@ def test_invoke_dispatches_autocomplete_with_dict_choices_unfiltered():
 def test_invoke_raises_for_unregistered_autocomplete_handler():
     bot = _bot()
 
-    @bot.command("shop", description="shop", options=[{"name": "item", "type": 3, "autocomplete": True}])
+    @bot.command(
+        "shop",
+        description="shop",
+        options=[{"name": "item", "type": 3, "description": "item to buy", "autocomplete": True}],
+    )
     async def shop(ctx, item: str):
         await ctx.send("bought")
 


### PR DESCRIPTION
## Changes

Adds `@bot.route(method, path)`: plain HTTP handlers on the same Lambda the bot already runs on, outside the Discord interaction flow. The request skips signature verification and the handler is called as `handler(event, bot)` with the raw Lambda event and the `Cordless` instance, so it can reuse `send_message`, `execute_webhook`, and the rest of the REST surface. For requests that need to land on the function without going through Discord: incoming webhooks from other services, OAuth redirect callbacks, health checks.

```python
@bot.route("POST", "/webhook")
async def incoming_webhook(event, bot):
    payload = json.loads(event["body"])
    await bot.send_message(CHANNEL_ID, f"event {payload['id']}")
    return {"received": True}
```

## Route surface

- **Matching**: exact paths, `{name}` segments (delivered on `event["pathParameters"]`), and a trailing greedy `{name+}`. A static route wins over one with a parameter in the same slot. Conflicting registrations raise at decoration time.
- **Return coercion**: `str` → text, `dict`/`list` → JSON, bare `int` → status, `(status, body)` / `(status, body, headers)` tuples, `bytes` → base64, or a full Lambda proxy dict passed through unchanged. `None` → empty `200`.
- **Errors**: `CordlessError` → `400`, anything else → `500` with the traceback in CloudWatch.
- **`POST /` is reserved** for Discord's interaction endpoint and cannot be registered.
- `@cog.route` mirrors `@bot.route`.
- `cordless dev` serves routes alongside interactions (`GET`/`POST`/`PUT`/`PATCH`/`DELETE`); the `GET /` banner stays when nothing claims that route.
- `testing.invoke_route(bot, method, path, ...)` dispatches through the real router with no HTTP layer, returning `RouteResponse(status, body, headers)`.

## Endpoints

Routes work on either `endpoint`:

- **`function_url`** (default): every path reaches the function and cordless does the matching. Nothing to configure. Unknown paths wake the Lambda for a cordless `404`.
- **`api_gateway`**: `cordless deploy` syncs routes onto the API next to the Discord commands (create new, prune removed), sharing one AWS_PROXY integration. Unknown paths `404` at the edge.

`deploy` and `cordless doctor` both list the registered routes either way; `doctor` and `_health_check` verify them against the live API when the endpoint is `api_gateway`.

## Command and option validation

Splitting `_validate_command_name` into `_validate_command_shape`, run at decoration time (and in `add_cog`). Catches the static limits that otherwise only surface as a positional `Invalid Form Body` error at register time, naming the command in every message: description length (1 to 100 on the command and every option), option name charset, and the 25-item caps on options and choices.

`register.sync_commands` now rewrites Discord's positional form-body errors (`errors.0.options.18.description`) into lines that name the command and option, falling back to the raw body when the response isn't that shape.

## Notable design decisions

- **`handle()` only inspects method/path when at least one route is registered**, so bots that never call `bot.route` are byte-for-byte unchanged.
- **`(event, bot)`, not a request wrapper.** `{param}` values are injected into `event["pathParameters"]` the same way API Gateway would, so handler code reads identically on both endpoints. Payload format 2.0 is identical between a Function URL and an API Gateway HTTP API, which is why routes work on both.
- **Adding a route never silently switches the endpoint.** An unset `endpoint` stays on the default Function URL; moving to `api_gateway` is an explicit `cordless.toml` change.
- **API Gateway route sync is destructive**, matching the command-sync model: the `<function>-api` API is cordless-owned, so routes not in the code are pruned.